### PR TITLE
feat!: adding BaseViewController and ViewModel

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
+++ b/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		96588BE82AD06CD20035FF93 /* MockTextInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96588BE72AD06CD20035FF93 /* MockTextInputViewModel.swift */; };
 		96588BEA2AD06CE30035FF93 /* MockTextFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96588BE92AD06CE30035FF93 /* MockTextFieldViewModel.swift */; };
 		96588BEC2AD6AD8A0035FF93 /* TextInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96588BEB2AD6AD8A0035FF93 /* TextInputViewControllerTests.swift */; };
+		968598AB2B03877D00462D0B /* BaseViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968598AA2B03877D00462D0B /* BaseViewControllerTests.swift */; };
+		968598AE2B03891000462D0B /* MockBaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968598AC2B03878900462D0B /* MockBaseViewModel.swift */; };
+		968598B12B03AA7E00462D0B /* MockBase.xib in Resources */ = {isa = PBXBuildFile; fileRef = 968598AF2B03A7C300462D0B /* MockBase.xib */; };
 		96FEBF922ACEC0F30067CC10 /* MockDatePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FEBF902ACEC0F30067CC10 /* MockDatePickerViewModel.swift */; };
 		96FEBF932ACEC0F30067CC10 /* MockDatePickerScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FEBF912ACEC0F30067CC10 /* MockDatePickerScreenViewModel.swift */; };
 		96FEFC192ACD9FF400313194 /* InstructionsWithImageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0843F62ABC797E00188BA0 /* InstructionsWithImageViewControllerTests.swift */; };
@@ -109,6 +112,9 @@
 		96588BE72AD06CD20035FF93 /* MockTextInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTextInputViewModel.swift; sourceTree = "<group>"; };
 		96588BE92AD06CE30035FF93 /* MockTextFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTextFieldViewModel.swift; sourceTree = "<group>"; };
 		96588BEB2AD6AD8A0035FF93 /* TextInputViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputViewControllerTests.swift; sourceTree = "<group>"; };
+		968598AA2B03877D00462D0B /* BaseViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewControllerTests.swift; sourceTree = "<group>"; };
+		968598AC2B03878900462D0B /* MockBaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBaseViewModel.swift; sourceTree = "<group>"; };
+		968598AF2B03A7C300462D0B /* MockBase.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MockBase.xib; sourceTree = "<group>"; };
 		96FEBF902ACEC0F30067CC10 /* MockDatePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDatePickerViewModel.swift; sourceTree = "<group>"; };
 		96FEBF912ACEC0F30067CC10 /* MockDatePickerScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDatePickerScreenViewModel.swift; sourceTree = "<group>"; };
 		C8C9297E2ACDCA1700A130C3 /* MockIntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIntroViewModel.swift; sourceTree = "<group>"; };
@@ -139,11 +145,13 @@
 			isa = PBXGroup;
 			children = (
 				7C51376E2AD99E9D00163E83 /* Mocks */,
+				968598AF2B03A7C300462D0B /* MockBase.xib */,
 				2B08440D2ABC7A4300188BA0 /* TestExtensions */,
 				2B0843F52ABC797E00188BA0 /* GDSInstructionsViewControllerTests.swift */,
 				2B0843F62ABC797E00188BA0 /* InstructionsWithImageViewControllerTests.swift */,
 				9634B4692ACDAE8E00A60CC8 /* ListOptionsViewControllerTests.swift */,
 				96588BDF2AD046420035FF93 /* DatePickerScreenViewControllerTests.swift */,
+				968598AA2B03877D00462D0B /* BaseViewControllerTests.swift */,
 				2B0843F42ABC797E00188BA0 /* MockGDSInstructionsViewModel.swift */,
 				2B0843F72ABC797E00188BA0 /* ModalInfoViewControllerTests.swift */,
 				2BB5C7882AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift */,
@@ -227,6 +235,7 @@
 		7C51376E2AD99E9D00163E83 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				968598AC2B03878900462D0B /* MockBaseViewModel.swift */,
 				7C51376F2AD99EB600163E83 /* Scanning */,
 			);
 			path = Mocks;
@@ -349,6 +358,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				968598B12B03AA7E00462D0B /* MockBase.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,6 +389,7 @@
 				7C5137772AD99F0B00163E83 /* MockBarcodeRequest.swift in Sources */,
 				7C5137792AD99F2300163E83 /* MockBarcodeObservation.swift in Sources */,
 				2B78F2FA2AD598FC003C3445 /* MockDialogPresenter.swift in Sources */,
+				968598AB2B03877D00462D0B /* BaseViewControllerTests.swift in Sources */,
 				3B61C6E12ACDC580001359F1 /* IntroViewControllerTests.swift in Sources */,
 				21AB39DC2B142B5400A26268 /* ResultsViewControllerTests.swift in Sources */,
 				2B08440B2ABC79C300188BA0 /* MockGDSInstructionsViewModel.swift in Sources */,
@@ -388,6 +399,7 @@
 				2BB5C7892AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift in Sources */,
 				7C51377B2AD9DA8A00163E83 /* MockCaptureDevice.swift in Sources */,
 				7C5137752AD99EF700163E83 /* MockDetectBarcodeRequest.swift in Sources */,
+				968598AE2B03891000462D0B /* MockBaseViewModel.swift in Sources */,
 				2B08440F2ABC7A5B00188BA0 /* UIView+Test_Extensions.swift in Sources */,
 				2B0844032ABC79BB00188BA0 /* GDSCommon_DemoTests.swift in Sources */,
 			);

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -9,9 +9,7 @@ extension DatePickerScreenViewController {
         
         let viewModel = MockDatePickerScreenViewModel(title: "Date picker screen",
                                                       datePickerViewModel: datePickerVM,
-                                                      buttonViewModel: MockButtonViewModel(title: "Action Button",
-                                                                                           shouldLoadOnTap: false,
-                                                                                           action: {}))
+                                                      buttonViewModel: MockButtonViewModel.primary)
         
         self.init(viewModel: viewModel)
     }
@@ -34,9 +32,11 @@ extension TextInputViewController<Double> {
 }
 
 extension GDSInstructionsViewController {
-    convenience init() {
-        let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockButtonViewModel(title: "Button title", action: {}), dismissAction: {})
-        
+    convenience init(popToRoot: @escaping (UINavigationController) -> Void, navController: UINavigationController) {
+        let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockButtonViewModel.primary,
+                                                     secondaryButtonViewModel: MockButtonViewModel.secondaryQR) {
+            popToRoot(navController)
+        }
         self.init(viewModel: viewModel)
     }
 }
@@ -45,6 +45,15 @@ extension IconScreenViewController {
     convenience init() {
         let viewModel = MockIconScreenViewModel()
         
+        self.init(viewModel: viewModel)
+    }
+}
+
+extension ResultsViewController {
+    convenience init(popToRoot: @escaping (UINavigationController) -> Void, navController: UINavigationController) {
+        let viewModel = MockResultsViewModel(resultsButtonViewModel: MockButtonViewModel.primary, rightBarButtonTitle: "right bar button") {
+            popToRoot(navController)
+        }
         self.init(viewModel: viewModel)
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -44,9 +44,13 @@ extension IconScreenViewController {
 }
 
 extension ResultsViewController {
-    convenience init(popToRoot: @escaping (UINavigationController) -> Void, navController: UINavigationController) {
+    convenience init(popToRoot: ((UINavigationController) -> Void)?, navController: UINavigationController) {
         let viewModel = MockResultsViewModel(resultsButtonViewModel: MockButtonViewModel.primary, rightBarButtonTitle: "right bar button") {
-            popToRoot(navController)
+            if let popToRoot {
+                popToRoot(navController)
+            } else {
+                navController.dismiss(animated: true)
+            }
         }
         self.init(viewModel: viewModel)
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -19,13 +19,7 @@ extension TextInputViewController<Double> {
     convenience init() {
         let textFieldVM = MockTextFieldViewModel<Double>()
         
-        let viewModel = MockTextInputViewModel<Double>(textFieldViewModel: textFieldVM) { _ in
-            // no result action
-        } appearAction: {
-            // no appear action
-        } dismissAction: {
-            // no dismiss action
-        }
+        let viewModel = MockTextInputViewModel<Double>(result: {_ in }, appearAction: {}, dismissAction: {})
 
         self.init(viewModel: viewModel)
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -35,7 +35,7 @@ extension TextInputViewController<Double> {
 
 extension GDSInstructionsViewController {
     convenience init() {
-        let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockButtonViewModel(title: "Button title", action: {}))
+        let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockButtonViewModel(title: "Button title", action: {}), dismissAction: {})
         
         self.init(viewModel: viewModel)
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -51,3 +51,12 @@ extension ResultsViewController {
         self.init(viewModel: viewModel)
     }
 }
+
+extension ListOptionsViewController {
+    convenience init(popToRoot: @escaping (UINavigationController) -> Void, navController: UINavigationController) {
+        let viewModel = MockListViewModel(dismissAction: {
+            popToRoot(navController)
+        })
+        self.init(viewModel: viewModel)
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -1,30 +1,34 @@
 import Foundation
 import GDSCommon
 
-class MockButtonViewModel: ButtonViewModel {
-    var title: GDSLocalisedString
-    var icon: ButtonIconViewModel?
-    var shouldLoadOnTap: Bool
-    var action: () -> Void
-    
-    init(title: GDSLocalisedString,
-         icon: ButtonIconViewModel? = nil,
-         shouldLoadOnTap: Bool = false,
-         action: @escaping () -> Void) {
-        self.title = title
-        self.icon = icon
-        self.shouldLoadOnTap = shouldLoadOnTap
-        self.action = action
-    }
+struct MockButtonViewModel: ButtonViewModel {
+    let title: GDSLocalisedString
+    let icon: ButtonIconViewModel?
+    let shouldLoadOnTap: Bool
+    let action: () -> Void
 }
   
-class MockButtonIconViewModel: ButtonIconViewModel {
-    var iconName: String
-    var symbolPosition: SymbolPosition
+struct MockButtonIconViewModel: ButtonIconViewModel {
+    let iconName: String
+    let symbolPosition: SymbolPosition
     
     init(iconName: String, symbolPosition: SymbolPosition) {
         self.iconName = iconName
         self.symbolPosition = symbolPosition
     }
 }
-  
+
+extension MockButtonViewModel {
+    static var primary: MockButtonViewModel {
+        MockButtonViewModel(title: "Action button", icon: nil, shouldLoadOnTap: false, action: {})
+    }
+    
+    static var secondaryQR: ButtonViewModel {
+        MockButtonViewModel(title: "Secondary Button",
+                            icon: MockButtonIconViewModel(iconName: "qrcode",
+                                                          symbolPosition: .beforeTitle),
+                            shouldLoadOnTap: false,
+                            action: {})
+    }
+}
+

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -7,7 +7,7 @@ struct MockButtonViewModel: ButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
 }
-  
+
 struct MockButtonIconViewModel: ButtonIconViewModel {
     let iconName: String
     let symbolPosition: SymbolPosition
@@ -26,4 +26,3 @@ extension MockButtonViewModel {
                             action: {})
     }
 }
-

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -11,11 +11,6 @@ struct MockButtonViewModel: ButtonViewModel {
 struct MockButtonIconViewModel: ButtonIconViewModel {
     let iconName: String
     let symbolPosition: SymbolPosition
-    
-    init(iconName: String, symbolPosition: SymbolPosition) {
-        self.iconName = iconName
-        self.symbolPosition = symbolPosition
-    }
 }
 
 extension MockButtonViewModel {

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
@@ -3,13 +3,13 @@ import Foundation
 
 @available(iOS 13.4, *)
 struct MockDatePickerScreenViewModel: DatePickerScreenViewModel, BaseViewModel {
-    var title: GDSLocalisedString
+    let title: GDSLocalisedString
     var datePickerViewModel: DatePickerViewModel
-    var datePickerFooter: String? = "Example date picker footer"
-    var buttonViewModel: ButtonViewModel
-    var rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
-    var backButtonIsHidden: Bool = false
-    var result: (Date) -> Void
+    let datePickerFooter: String? = "Example date picker footer"
+    let buttonViewModel: ButtonViewModel
+    let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
+    let backButtonIsHidden: Bool = false
+    let result: (Date) -> Void
     
     let appearAction: () -> Void
     let dismissAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import GDSCommon
 
 @available(iOS 13.4, *)
-struct MockDatePickerScreenViewModel: DatePickerScreenViewModel {
+struct MockDatePickerScreenViewModel: DatePickerScreenViewModel, BaseViewModel {
     var title: GDSLocalisedString
     var datePickerViewModel: DatePickerViewModel
     var datePickerFooter: String? = "Example date picker footer"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
@@ -8,6 +8,7 @@ struct MockDatePickerScreenViewModel: DatePickerScreenViewModel {
     var datePickerFooter: String? = "Example date picker footer"
     var buttonViewModel: ButtonViewModel
     var rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
+    var backButtonIsHidden: Bool = false
     var result: (Date) -> Void
     
     let appearAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockDatePickerScreenViewModel.swift
@@ -38,6 +38,8 @@ struct MockDatePickerScreenViewModel: DatePickerScreenViewModel, BaseViewModel {
             self.buttonViewModel = buttonViewModel
         } else {
             self.buttonViewModel = MockButtonViewModel(title: "button title",
+                                                       icon: nil,
+                                                       shouldLoadOnTap: false,
                                                        action: buttonAction ?? {})
         }
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -2,16 +2,16 @@ import GDSCommon
 import UIKit
 
 struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
-    var title: GDSLocalisedString = "This is the Instructions View"
-    var body: String = "We can add a subtitle here to give some extra context"
-    var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
-    var childView: UIView = BulletView(title: "This is the bullet view",
+    let title: GDSLocalisedString = "This is the Instructions View"
+    let body: String = "We can add a subtitle here to give some extra context"
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let childView: UIView = BulletView(title: "This is the bullet view",
                                        text: ["Here we can list things we want the user to know",
                                               "we can use this as a way to step them through an action",
                                               "or give details of a process"])
-    var buttonViewModel: ButtonViewModel
-    var secondaryButtonViewModel: ButtonViewModel?
-    var backButtonIsHidden: Bool = false
+    let buttonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    let backButtonIsHidden: Bool = false
     
     let dismissAction: () -> Void
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -1,28 +1,22 @@
 import GDSCommon
 import UIKit
 
-class MockGDSInstructionsViewModel: GDSInstructionsViewModel {
-    var title: GDSLocalisedString
-    var body: String
+struct MockGDSInstructionsViewModel: GDSInstructionsViewModel {
+    var title: GDSLocalisedString = "This is the Instructions View"
+    var body: String = "We can add a subtitle here to give some extra context"
     var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
-    var childView: UIView
+    var childView: UIView = BulletView(title: "This is the bullet view",
+                                     text: ["Here we can list things we want the user to know",
+                                            "we can use this as a way to step them through an action",
+                                            "or give details of a process"])
     var buttonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
-    func didAppear() {}
-    func didDismiss() {}
+    var backButtonIsHidden: Bool = false
     
-    init(title: GDSLocalisedString = "This is the Instructions View",
-         body: String = "We can add a subtitle here to give some extra context",
-         childView: UIView = BulletView(title: "This is the bullet view",
-                                        text: ["Here we can list things we want the user to know",
-                                               "we can use this as a way to step them through an action",
-                                               "or give details of a process"]),
-         buttonViewModel: ButtonViewModel,
-         secondaryButtonViewModel: ButtonViewModel? = nil) {
-        self.title = title
-        self.body = body
-        self.childView = childView
-        self.buttonViewModel = buttonViewModel
-        self.secondaryButtonViewModel = secondaryButtonViewModel
+    let dismissAction: () -> Void
+    
+    func didAppear() {}
+    func didDismiss() {
+        dismissAction()
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -6,9 +6,9 @@ struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     var body: String = "We can add a subtitle here to give some extra context"
     var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
     var childView: UIView = BulletView(title: "This is the bullet view",
-                                     text: ["Here we can list things we want the user to know",
-                                            "we can use this as a way to step them through an action",
-                                            "or give details of a process"])
+                                       text: ["Here we can list things we want the user to know",
+                                              "we can use this as a way to step them through an action",
+                                              "or give details of a process"])
     var buttonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
     var backButtonIsHidden: Bool = false

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-struct MockGDSInstructionsViewModel: GDSInstructionsViewModel {
+struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     var title: GDSLocalisedString = "This is the Instructions View"
     var body: String = "We can add a subtitle here to give some extra context"
     var rightBarButtonTitle: GDSLocalisedString? = "right bar button"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
@@ -6,8 +6,11 @@ public struct MockIconScreenViewModel: IconScreenViewModel {
     public let title: GDSLocalisedString = "Example title text"
     public let body: GDSLocalisedString = "Example subtitle text string for testing purposes"
     public let childViews: [UIView]
+    public let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    public var backButtonIsHidden: Bool = false
     
     public func didAppear() { }
+    public func didDismiss() { }
     
     public init() {
         let optionViewModel1 = MockOptionViewModel1()

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
@@ -1,18 +1,18 @@
 import GDSCommon
 import UIKit
 
-public struct MockIconScreenViewModel: IconScreenViewModel, BaseViewModel {
-    public let imageName: String = "exclamationmark.circle"
-    public let title: GDSLocalisedString = "Example title text"
-    public let body: GDSLocalisedString = "Example subtitle text string for testing purposes"
-    public let childViews: [UIView]
-    public let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
-    public var backButtonIsHidden: Bool = false
+struct MockIconScreenViewModel: IconScreenViewModel, BaseViewModel {
+    let imageName: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "Example title text"
+    let body: GDSLocalisedString = "Example subtitle text string for testing purposes"
+    let childViews: [UIView]
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let backButtonIsHidden: Bool = false
     
-    public func didAppear() { }
-    public func didDismiss() { }
+    func didAppear() { }
+    func didDismiss() { }
     
-    public init() {
+    init() {
         let optionViewModel1 = MockOptionViewModel1()
         let optionView1 = OptionView(viewModel: optionViewModel1)
         let optionViewModel2 = MockOptionViewModel2()

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIconScreenViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-public struct MockIconScreenViewModel: IconScreenViewModel {
+public struct MockIconScreenViewModel: IconScreenViewModel, BaseViewModel {
     public let imageName: String = "exclamationmark.circle"
     public let title: GDSLocalisedString = "Example title text"
     public let body: GDSLocalisedString = "Example subtitle text string for testing purposes"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
@@ -9,6 +9,7 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel {
     var primaryButtonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
     var rightBarButtonTitle: GDSLocalisedString?
+    var backButtonIsHidden: Bool = false
 
     let screenView: () -> Void
     let dismissAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel {
+class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseViewModel {
     var title: GDSLocalisedString
     var body: NSAttributedString
     var image: UIImage

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
@@ -6,6 +6,9 @@ struct MockIntroViewModel: IntroViewModel {
     var title: GDSLocalisedString = "This is a Intro Screen"
     var body: GDSLocalisedString = "This is the body where we can give a brief description of the app"
     var introButtonViewModel: ButtonViewModel
+    var rightBarButtonTitle: GDSLocalisedString? = nil
+    var backButtonIsHidden: Bool = false
     
     func didAppear() { }
+    func didDismiss() { }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
@@ -6,7 +6,7 @@ struct MockIntroViewModel: IntroViewModel {
     var title: GDSLocalisedString = "This is a Intro Screen"
     var body: GDSLocalisedString = "This is the body where we can give a brief description of the app"
     var introButtonViewModel: ButtonViewModel
-    var rightBarButtonTitle: GDSLocalisedString? = nil
+    var rightBarButtonTitle: GDSLocalisedString?
     var backButtonIsHidden: Bool = false
     
     func didAppear() { }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
@@ -2,12 +2,12 @@ import GDSCommon
 import UIKit
 
 struct MockIntroViewModel: IntroViewModel, BaseViewModel {
-    var image: UIImage = UIImage(named: "badge") ?? UIImage()
-    var title: GDSLocalisedString = "This is a Intro Screen"
-    var body: GDSLocalisedString = "This is the body where we can give a brief description of the app"
-    var introButtonViewModel: ButtonViewModel
-    var rightBarButtonTitle: GDSLocalisedString?
-    var backButtonIsHidden: Bool = false
+    let image: UIImage = UIImage(named: "badge") ?? UIImage()
+    let title: GDSLocalisedString = "This is a Intro Screen"
+    let body: GDSLocalisedString = "This is the body where we can give a brief description of the app"
+    let introButtonViewModel: ButtonViewModel
+    let rightBarButtonTitle: GDSLocalisedString?
+    let backButtonIsHidden: Bool = false
     
     func didAppear() { }
     func didDismiss() { }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-struct MockIntroViewModel: IntroViewModel {
+struct MockIntroViewModel: IntroViewModel, BaseViewModel {
     var image: UIImage = UIImage(named: "badge") ?? UIImage()
     var title: GDSLocalisedString = "This is a Intro Screen"
     var body: GDSLocalisedString = "This is the body where we can give a brief description of the app"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -32,6 +32,8 @@ struct MockListViewModel: ListOptionsViewModel, BaseViewModel {
         self.dismissAction = dismissAction ?? {}
         
         buttonViewModel = MockButtonViewModel(title: "Action button",
+                                              icon: nil, 
+                                              shouldLoadOnTap: false,
                                               action: dismissAction ?? {})
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -32,7 +32,7 @@ struct MockListViewModel: ListOptionsViewModel, BaseViewModel {
         self.dismissAction = dismissAction ?? {}
         
         buttonViewModel = MockButtonViewModel(title: "Action button",
-                                              icon: nil, 
+                                              icon: nil,
                                               shouldLoadOnTap: false,
                                               action: dismissAction ?? {})
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -8,7 +8,7 @@ struct MockListViewModel: ListOptionsViewModel, BaseViewModel {
     let buttonViewModel: ButtonViewModel
     let resultAction: (GDSLocalisedString) -> Void
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
-    var backButtonIsHidden: Bool = false
+    let backButtonIsHidden: Bool = false
     
     let screenView: () -> Void
     let dismissAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -8,6 +8,7 @@ struct MockListViewModel: ListOptionsViewModel {
     let buttonViewModel: ButtonViewModel
     let resultAction: (GDSLocalisedString) -> Void
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
+    var backButtonIsHidden: Bool = false
     
     let screenView: () -> Void
     let dismissAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -1,6 +1,6 @@
 import GDSCommon
 
-struct MockListViewModel: ListOptionsViewModel {
+struct MockListViewModel: ListOptionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the List Options screen pattern"
     let body: String? = "This is the optional body label. If the view model property is `nil` then the label is hidden."
     let listRows: [GDSLocalisedString] = ["Table view list item 1", "Table view list item two", "Table view list item 3", "Table view list item IV"]

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -2,18 +2,22 @@ import Foundation
 import GDSCommon
 import UIKit
 
-class MockModalInfoViewModel: ModalInfoViewModel {
+struct MockModalInfoViewModel: ModalInfoViewModel {
     var title: GDSLocalisedString = "This is the modal view"
     var body: GDSLocalisedString = "We can use this if we want the user to complete an action"
-    var rightBarButtonTitle: GDSLocalisedString = "Close"
+    var rightBarButtonTitle: GDSLocalisedString? = "Close"
+    var backButtonIsHidden: Bool = false
+    
     func didAppear() {}
     func didDismiss() {}
 }
 
-class MockAttributedModalInfoViewModel: ModalInfoViewModel {
+struct MockAttributedModalInfoViewModel: ModalInfoViewModel {
     var title: GDSLocalisedString = "This is the modal view"
     var body: GDSLocalisedString = .init(stringLiteral: "We can use this if we want the user to complete an action", attributes: [("We can use this", [.font: UIFont.bodyBold])])
-    var rightBarButtonTitle: GDSLocalisedString = "Close"
+    var rightBarButtonTitle: GDSLocalisedString? = "Close"
+    var backButtonIsHidden: Bool = false
+    
     func didAppear() {}
     func didDismiss() {}
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -3,20 +3,20 @@ import GDSCommon
 import UIKit
 
 struct MockModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
-    var title: GDSLocalisedString = "This is the modal view"
-    var body: GDSLocalisedString = "We can use this if we want the user to complete an action"
-    var rightBarButtonTitle: GDSLocalisedString? = "Close"
-    var backButtonIsHidden: Bool = false
+    let title: GDSLocalisedString = "This is the modal view"
+    let body: GDSLocalisedString = "We can use this if we want the user to complete an action"
+    let rightBarButtonTitle: GDSLocalisedString? = "Close"
+    let backButtonIsHidden: Bool = false
     
     func didAppear() {}
     func didDismiss() {}
 }
 
 struct MockAttributedModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
-    var title: GDSLocalisedString = "This is the modal view"
-    var body: GDSLocalisedString = .init(stringLiteral: "We can use this if we want the user to complete an action", attributes: [("We can use this", [.font: UIFont.bodyBold])])
-    var rightBarButtonTitle: GDSLocalisedString? = "Close"
-    var backButtonIsHidden: Bool = false
+    let title: GDSLocalisedString = "This is the modal view"
+    let body: GDSLocalisedString = .init(stringLiteral: "We can use this if we want the user to complete an action", attributes: [("We can use this", [.font: UIFont.bodyBold])])
+    let rightBarButtonTitle: GDSLocalisedString? = "Close"
+    let backButtonIsHidden: Bool = false
     
     func didAppear() {}
     func didDismiss() {}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import GDSCommon
 import UIKit
 
-struct MockModalInfoViewModel: ModalInfoViewModel {
+struct MockModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     var title: GDSLocalisedString = "This is the modal view"
     var body: GDSLocalisedString = "We can use this if we want the user to complete an action"
     var rightBarButtonTitle: GDSLocalisedString? = "Close"
@@ -12,7 +12,7 @@ struct MockModalInfoViewModel: ModalInfoViewModel {
     func didDismiss() {}
 }
 
-struct MockAttributedModalInfoViewModel: ModalInfoViewModel {
+struct MockAttributedModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     var title: GDSLocalisedString = "This is the modal view"
     var body: GDSLocalisedString = .init(stringLiteral: "We can use this if we want the user to complete an action", attributes: [("We can use this", [.font: UIFont.bodyBold])])
     var rightBarButtonTitle: GDSLocalisedString? = "Close"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
@@ -1,19 +1,19 @@
 import GDSCommon
 
-public struct MockOptionViewModel1: OptionViewModel {
-    public let title: GDSLocalisedString = "Example title text 1"
-    public let subtitle: GDSLocalisedString = "Example subtitle text 1"
-    public let buttonViewModel: ButtonViewModel = MockOptionButtonViewModel()
+struct MockOptionViewModel1: OptionViewModel {
+    let title: GDSLocalisedString = "Example title text 1"
+    let subtitle: GDSLocalisedString = "Example subtitle text 1"
+    let buttonViewModel: ButtonViewModel = MockOptionButtonViewModel()
     
-    public init() { }
+    init() { }
 }
 
-public struct MockOptionViewModel2: OptionViewModel {
-    public let title: GDSLocalisedString = "Example title text 2"
-    public let subtitle: GDSLocalisedString = "Example subtitle text 2"
-    public let buttonViewModel: ButtonViewModel = MockOptionButtonViewModel()
+struct MockOptionViewModel2: OptionViewModel {
+    let title: GDSLocalisedString = "Example title text 2"
+    let subtitle: GDSLocalisedString = "Example subtitle text 2"
+    let buttonViewModel: ButtonViewModel = MockOptionButtonViewModel()
     
-    public init() { }
+    init() { }
 }
 
 struct MockOptionButtonViewModel: ButtonViewModel {

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockQRScanningViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockQRScanningViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-class MockQRScanningViewModel: QRScanningViewModel {
+class MockQRScanningViewModel: QRScanningViewModel, BaseViewModel {
     let title: String
     let instructionText: String
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockQRScanningViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockQRScanningViewModel.swift
@@ -5,6 +5,7 @@ class MockQRScanningViewModel: QRScanningViewModel {
     let title: String
     let instructionText: String
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    var backButtonIsHidden: Bool = false
     
     let dialogPresenter: DialogPresenter
     let onScan: () -> Void
@@ -37,6 +38,8 @@ class MockQRScanningViewModel: QRScanningViewModel {
                                       title: "QR Code Scanned")
         onScan()
     }
+    
+    func didAppear() { }
     
     func didDismiss() {
         dismissAction()

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockResultsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockResultsViewModel.swift
@@ -1,11 +1,13 @@
 import GDSCommon
 import UIKit
 
-struct MockResultsViewModel: ResultsViewModel {
-    var image: String = "checkmark.circle"
-    var title: GDSLocalisedString = "This is a results screen"
-    var body: GDSLocalisedString? = "This is the body where we can give a brief description of the app"
-    var resultsButtonViewModel: ButtonViewModel
+struct MockResultsViewModel: ResultsViewModel, BaseViewModel {
+    let image: String = "checkmark.circle"
+    let title: GDSLocalisedString = "This is a results screen"
+    let body: GDSLocalisedString? = "This is the body where we can give a brief description of the app"
+    let resultsButtonViewModel: ButtonViewModel
+    let rightBarButtonTitle: GDSLocalisedString?
+    let backButtonIsHidden: Bool = false
     
     let dismissAction: () -> Void
     
@@ -14,5 +16,4 @@ struct MockResultsViewModel: ResultsViewModel {
     func didDismiss() {
         dismissAction()
     }
-
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextFieldViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextFieldViewModel.swift
@@ -3,12 +3,12 @@ import UIKit
 
 struct MockTextFieldViewModel<InputType>: TextFieldViewModel {
     typealias InputType = Bool
-    var keyboardType: UIKeyboardType = .default
-    var placeholder: String? = "Placeholder"
-    var keyboardDoneButton: String? = "done button"
+    let keyboardType: UIKeyboardType = .default
+    let placeholder: String? = "Placeholder"
+    let keyboardDoneButton: String? = "done button"
     
-    var shouldValidate = true
-    var result = false
+    let shouldValidate = true
+    let result = false
     
     func validator(existingString: String?, range: NSRange, replacementString: String) -> Bool {
         shouldValidate

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
@@ -1,7 +1,7 @@
 @testable import GDSCommon
 import UIKit
 
-struct MockTextInputViewModel<InputType>: TextInputViewModel {
+struct MockTextInputViewModel<InputType>: TextInputViewModel, BaseViewModel {
     typealias InputType = Bool
     var textFieldViewModel: any TextFieldViewModel = MockTextFieldViewModel<InputType>()
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
@@ -3,13 +3,13 @@ import UIKit
 
 struct MockTextInputViewModel<InputType>: TextInputViewModel, BaseViewModel {
     typealias InputType = Bool
-    var textFieldViewModel: any TextFieldViewModel = MockTextFieldViewModel<InputType>()
+    let textFieldViewModel: any TextFieldViewModel = MockTextFieldViewModel<InputType>()
     
     let title: GDSLocalisedString = "Text input screen title"
     let textFieldFooter: String? = "This is an optional footer. It is configured on the view model. If `nil` the label is hidden."
     let buttonViewModel: ButtonViewModel = MockButtonViewModel.primary
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
-    var backButtonIsHidden: Bool = false
+    let backButtonIsHidden: Bool = false
     let result: (Bool) -> Void
     
     let appearAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
@@ -11,6 +11,7 @@ struct MockTextInputViewModel<InputType>: TextInputViewModel {
         print("button was tapped")
     }
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
+    var backButtonIsHidden: Bool = false
     let result: (Bool) -> Void
     
     let appearAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockTextInputViewModel.swift
@@ -7,9 +7,7 @@ struct MockTextInputViewModel<InputType>: TextInputViewModel, BaseViewModel {
     
     let title: GDSLocalisedString = "Text input screen title"
     let textFieldFooter: String? = "This is an optional footer. It is configured on the view model. If `nil` the label is hidden."
-    let buttonViewModel: ButtonViewModel = MockButtonViewModel(title: "Action button") {
-        print("button was tapped")
-    }
+    let buttonViewModel: ButtonViewModel = MockButtonViewModel.primary
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
     var backButtonIsHidden: Bool = false
     let result: (Bool) -> Void

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -107,7 +107,9 @@ enum Screens: String, CaseIterable {
             let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) } dismissAction: {}
             return ScanningViewController(viewModel: viewModel)
         case .gdsResultsView, .gdsResultsViewModal:
-            let viewModel = MockResultsViewModel(resultsButtonViewModel: mockButtonViewModel, dismissAction: {})
+            let viewModel = MockResultsViewModel(resultsButtonViewModel: mockButtonViewModel, rightBarButtonTitle: "right bar button") {
+                navigationController.popViewController(animated: true)
+            }
             return ResultsViewController(viewModel: viewModel)
         }
     }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -72,9 +72,7 @@ enum Screens: String, CaseIterable {
             view.isModalInPresentation = true
             return view
         case .gdsListOptions:
-            return ListOptionsViewController(viewModel: MockListViewModel(dismissAction: {
-                navigationController.popToRootViewController(animated: true)
-            }))
+            return ListOptionsViewController(popToRoot: popToRoot, navController: navigationController)
         case .gdsIntroView:
             let viewModel = MockIntroViewModel(introButtonViewModel: MockButtonViewModel.primary, rightBarButtonTitle: nil)
             return IntroViewController(viewModel: viewModel)

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -89,7 +89,7 @@ enum Screens: String, CaseIterable {
             let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) } dismissAction: {}
             return ScanningViewController(viewModel: viewModel)
         case .gdsResultsView, .gdsResultsViewModal:
-            return ResultsViewController(popToRoot: popToRoot, navController: navigationController)
+            return ResultsViewController(popToRoot: self == .gdsResultsView ? popToRoot : nil, navController: navigationController)
         }
     }
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -61,7 +61,9 @@ enum Screens: String, CaseIterable {
         switch self {
         case .gdsInstructions:
             let viewModel = MockGDSInstructionsViewModel(buttonViewModel: mockButtonViewModel,
-                                                         secondaryButtonViewModel: mockSecondaryButtonViewModel)
+                                                         secondaryButtonViewModel: mockSecondaryButtonViewModel) {
+                navigationController.popToRootViewController(animated: true)
+            }
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
@@ -88,7 +90,9 @@ enum Screens: String, CaseIterable {
             view.isModalInPresentation = true
             return view
         case .gdsListOptions:
-            return ListOptionsViewController(viewModel: MockListViewModel())
+            return ListOptionsViewController(viewModel: MockListViewModel(dismissAction: {
+                navigationController.popToRootViewController(animated: true)
+            }))
         case .gdsIntroView:
             let viewModel = MockIntroViewModel(introButtonViewModel: mockButtonViewModel)
             return IntroViewController(viewModel: viewModel)

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -76,7 +76,7 @@ enum Screens: String, CaseIterable {
                 navigationController.popToRootViewController(animated: true)
             }))
         case .gdsIntroView:
-            let viewModel = MockIntroViewModel(introButtonViewModel: MockButtonViewModel.primary)
+            let viewModel = MockIntroViewModel(introButtonViewModel: MockButtonViewModel.primary, rightBarButtonTitle: nil)
             return IntroViewController(viewModel: viewModel)
         case .gdsDatePicker:
             return DatePickerScreenViewController()

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -40,18 +40,6 @@ enum Screens: String, CaseIterable {
         }
     }
     
-    private var mockButtonViewModel: ButtonViewModel {
-        MockButtonViewModel(title: "Action Button", shouldLoadOnTap: false, action: {})
-    }
-    
-    private var mockSecondaryButtonViewModel: ButtonViewModel {
-        MockButtonViewModel(title: "Secondary Button",
-                            icon: MockButtonIconViewModel(iconName: "qrcode",
-                                                          symbolPosition: .beforeTitle),
-                            shouldLoadOnTap: false,
-                            action: {})
-    }
-    
     private var dialogPresenter: DialogPresenter {
         DialogView<CheckmarkDialogAccessoryView>(title: "QR Scan Success",
                                                  isLoading: false)
@@ -60,20 +48,16 @@ enum Screens: String, CaseIterable {
     func create(in navigationController: UINavigationController) -> UIViewController {
         switch self {
         case .gdsInstructions:
-            let viewModel = MockGDSInstructionsViewModel(buttonViewModel: mockButtonViewModel,
-                                                         secondaryButtonViewModel: mockSecondaryButtonViewModel) {
-                navigationController.popToRootViewController(animated: true)
-            }
-            return GDSInstructionsViewController(viewModel: viewModel)
+            return GDSInstructionsViewController(popToRoot: popToRoot, navController: navigationController)
         case .gdsInstructionsWithImage:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
-                                                               primaryButtonViewModel: mockButtonViewModel,
+            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
+                                                               primaryButtonViewModel: MockButtonViewModel.primary,
                                                                screenView: {}, dismissAction: {})
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
-                                                               primaryButtonViewModel: mockButtonViewModel,
-                                                               secondaryButtonViewModel: mockSecondaryButtonViewModel,
+            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
+                                                               primaryButtonViewModel: MockButtonViewModel.primary,
+                                                               secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
                                                                rightBarButtonTitle: "Close",
                                                                screenView: {}, dismissAction: {})
             return InstructionsWithImageViewController(viewModel: viewModel)
@@ -92,7 +76,7 @@ enum Screens: String, CaseIterable {
                 navigationController.popToRootViewController(animated: true)
             }))
         case .gdsIntroView:
-            let viewModel = MockIntroViewModel(introButtonViewModel: mockButtonViewModel)
+            let viewModel = MockIntroViewModel(introButtonViewModel: MockButtonViewModel.primary)
             return IntroViewController(viewModel: viewModel)
         case .gdsDatePicker:
             return DatePickerScreenViewController()
@@ -107,10 +91,11 @@ enum Screens: String, CaseIterable {
             let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) } dismissAction: {}
             return ScanningViewController(viewModel: viewModel)
         case .gdsResultsView, .gdsResultsViewModal:
-            let viewModel = MockResultsViewModel(resultsButtonViewModel: mockButtonViewModel, rightBarButtonTitle: "right bar button") {
-                navigationController.popViewController(animated: true)
-            }
-            return ResultsViewController(viewModel: viewModel)
+            return ResultsViewController(popToRoot: popToRoot, navController: navigationController)
         }
+    }
+    
+    func popToRoot(_ navigationController: UINavigationController) {
+        navigationController.popViewController(animated: true)
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -68,16 +68,14 @@ enum Screens: String, CaseIterable {
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
                                                                primaryButtonViewModel: mockButtonViewModel,
-                                                               screenView: {},
-                                                               dismissAction: {})
+                                                               screenView: {}, dismissAction: {})
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
                                                                primaryButtonViewModel: mockButtonViewModel,
                                                                secondaryButtonViewModel: mockSecondaryButtonViewModel,
                                                                rightBarButtonTitle: "Close",
-                                                               screenView: {},
-                                                               dismissAction: {})
+                                                               screenView: {}, dismissAction: {})
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsModalInfoView:
             let viewModel = MockModalInfoViewModel()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
@@ -26,7 +26,6 @@ final class BaseViewControllerTests: XCTestCase {
 
 extension BaseViewControllerTests {
     func test_labelContents() throws {
-        dump(sut)
         sut.beginAppearanceTransition(true, animated: false)
         sut.viewDidAppear(false)
         sut.endAppearanceTransition()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
@@ -5,13 +5,17 @@ import XCTest
 final class BaseViewControllerTests: XCTestCase {
     var viewModel: BaseViewModel!
     var sut: BaseViewController!
+    var didAppear: Bool!
+    var didDismiss: Bool!
     
     override func setUp() {
         super.setUp()
+        didAppear = false
+        didDismiss = false
         viewModel = MockBaseViewModel {
-            
+            self.didAppear = true
         } dismissAction: {
-            
+            self.didDismiss = true
         }
         sut = BaseViewController(viewModel: viewModel, nibName: "MockBase", bundle: .init(for: BaseViewControllerTests.self))
     }
@@ -31,5 +35,25 @@ extension BaseViewControllerTests {
         sut.endAppearanceTransition()
         let rightBarButton: UIBarButtonItem = try XCTUnwrap(sut.navigationItem.rightBarButtonItem)
         XCTAssertEqual(rightBarButton.title, "right bar button")
+    }
+    
+    func test_didAppear() {
+        XCTAssertFalse(didAppear)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
+        sut.endAppearanceTransition()
+        XCTAssertTrue(didAppear)
+    }
+    
+    func test_didDismiss() {
+        XCTAssertFalse(didAppear)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
+        sut.endAppearanceTransition()
+        XCTAssertTrue(didAppear)
+        
+        XCTAssertFalse(didDismiss)
+        _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
+        XCTAssertTrue(didDismiss)
     }
 }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
@@ -23,6 +23,8 @@ final class BaseViewControllerTests: XCTestCase {
     override func tearDown() {
         viewModel = nil
         sut = nil
+        didAppear = nil
+        didDismiss = nil
         
         super.tearDown()
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
@@ -1,0 +1,36 @@
+@testable import GDSCommon
+import GDSCommon_Demo
+import XCTest
+
+final class BaseViewControllerTests: XCTestCase {
+    var viewModel: BaseViewModel!
+    var sut: BaseViewController!
+    
+    override func setUp() {
+        super.setUp()
+        viewModel = MockBaseViewModel {
+            
+        } dismissAction: {
+            
+        }
+        sut = BaseViewController(viewModel: viewModel, nibName: "MockBase", bundle: .init(for: BaseViewControllerTests.self))
+    }
+    
+    override func tearDown() {
+        viewModel = nil
+        sut = nil
+        
+        super.tearDown()
+    }
+}
+
+extension BaseViewControllerTests {
+    func test_labelContents() throws {
+        dump(sut)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
+        sut.endAppearanceTransition()
+        let rightBarButton: UIBarButtonItem = try XCTUnwrap(sut.navigationItem.rightBarButtonItem)
+        XCTAssertEqual(rightBarButton.title, "right bar button")
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -14,7 +14,7 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
     var didTapPrimaryButton = false
     var didTapSecondaryButton = false
     var didTapWarningButton = false
-    
+
     override func setUp() {
         super.setUp()
         
@@ -42,13 +42,12 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
         
         attachToWindow(viewController: sut)
     }
-    
+
     override func tearDown() {
         buttonViewModel = nil
         warningButtonViewModel = nil
         viewModel = nil
         sut = nil
-    
         super.tearDown()
     }
 }
@@ -68,9 +67,9 @@ extension InstructionsWithImageViewControllerTests {
         sut.beginAppearanceTransition(true, animated: false)
         XCTAssertNotNil(sut.navigationItem.rightBarButtonItem)
         XCTAssertEqual(sut.navigationItem.rightBarButtonItem?.title, "close")
-
+        
         XCTAssertFalse(screenDidDismiss)
-
+        
         _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
         XCTAssertTrue(screenDidDismiss)
     }
@@ -98,7 +97,7 @@ extension InstructionsWithImageViewControllerTests {
         XCTAssertEqual(try sut.primaryButton.backgroundColor, .gdsGreen)
         XCTAssertEqual(try sut.primaryButton.icon, viewModel.primaryButtonViewModel.icon?.iconName)
         XCTAssertEqual(try sut.primaryButton.symbolPosition, viewModel.primaryButtonViewModel.icon?.symbolPosition)
-
+        
         try sut.primaryButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didTapPrimaryButton)
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -6,6 +6,7 @@ final class IntroViewControllerTests: XCTestCase {
     var sut: IntroViewController!
     var buttonAction = false
     var viewDidAppear = false
+    var viewDidDismiss = false
     
     override func setUp() {
         super.setUp()
@@ -14,6 +15,8 @@ final class IntroViewControllerTests: XCTestCase {
             self.buttonAction = true
         } appearAction: {
             self.viewDidAppear = true
+        } dismissAction: {
+            self.viewDidDismiss = true
         }
         sut = IntroViewController(viewModel: viewModel)
     }
@@ -31,18 +34,28 @@ private struct TestViewModel: IntroViewModel {
     let title: GDSLocalisedString = "Intro screen title"
     let body: GDSLocalisedString = "Intro screen body"
     let introButtonViewModel: ButtonViewModel
+    var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    var backButtonIsHidden: Bool = false
     let appearAction: () -> Void
+    let dismissAction: () -> Void
     
     init(buttonAction: @escaping () -> Void,
-         appearAction: @escaping () -> Void) {
+         appearAction: @escaping () -> Void,
+         dismissAction: @escaping () -> Void
+    ) {
         introButtonViewModel = MockButtonViewModel(title: "Intro screen button title") {
             buttonAction()
         }
         self.appearAction = appearAction
+        self.dismissAction = dismissAction
     }
     
     func didAppear() {
         appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
     }
 }
 

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -29,7 +29,7 @@ final class IntroViewControllerTests: XCTestCase {
     }
 }
 
-private struct TestViewModel: IntroViewModel {
+private struct TestViewModel: IntroViewModel, BaseViewModel {
     let image: UIImage = UIImage()
     let title: GDSLocalisedString = "Intro screen title"
     let body: GDSLocalisedString = "Intro screen body"
@@ -79,6 +79,7 @@ extension IntroViewControllerTests {
     func test_viewDidAppear() throws {
         XCTAssertFalse(viewDidAppear)
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         XCTAssertTrue(viewDidAppear)
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/MockBase.xib
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/MockBase.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BaseViewController" customModule="GDSCommon_DemoTests" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="wyO-DU-FGx" id="me0-Pg-Q8d"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="wyO-DU-FGx">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <viewLayoutGuide key="safeArea" id="hUv-c3-bjl"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <point key="canvasLocation" x="-456" y="-256"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel {
+internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "test title"
     let body: String = "test body"
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
@@ -8,6 +8,7 @@ internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel {
     let childView: UIView
     let buttonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
+    let backButtonIsHidden: Bool = false
     
     let screenView: () -> Void
     let dismissAction: () -> Void

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockBaseViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockBaseViewModel.swift
@@ -1,0 +1,17 @@
+@testable import GDSCommon
+
+struct MockBaseViewModel: BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    var backButtonIsHidden: Bool = false
+    
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -22,7 +22,8 @@ final class ModalInfoViewControllerTests: XCTestCase {
 private struct TestViewModel: ModalInfoViewModel {
     var title: GDSLocalisedString = "permissions screen title"
     var body: GDSLocalisedString = "permissions screen body"
-    var rightBarButtonTitle: GDSLocalisedString = "Done"
+    var rightBarButtonTitle: GDSLocalisedString? = "Done"
+    var backButtonIsHidden: Bool = false
     
     func didAppear() { }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -19,7 +19,7 @@ final class ModalInfoViewControllerTests: XCTestCase {
     }
 }
 
-private struct TestViewModel: ModalInfoViewModel {
+private struct TestViewModel: ModalInfoViewModel, BaseViewModel {
     var title: GDSLocalisedString = "permissions screen title"
     var body: GDSLocalisedString = "permissions screen body"
     var rightBarButtonTitle: GDSLocalisedString? = "Done"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
@@ -28,11 +28,14 @@ final class ResultsViewControllerTests: XCTestCase {
     }
 }
 
-private struct TestViewModel: ResultsViewModel {
+private struct TestViewModel: ResultsViewModel, BaseViewModel {
     let image: String = "checkmark.circle"
     let title: GDSLocalisedString = "Results title"
     let body: GDSLocalisedString? = "Results body"
     let resultsButtonViewModel: ButtonViewModel
+    var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    var backButtonIsHidden: Bool = true
+    
     let dismissAction: () -> Void
     let appearAction: () -> Void
     
@@ -55,7 +58,8 @@ private struct TestViewModel: ResultsViewModel {
 extension ResultsViewControllerTests {
     func testDidAppear() {
         XCTAssertFalse(screenDidAppear)
-        sut.viewDidAppear(false)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
         XCTAssertTrue(screenDidAppear)
     }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
@@ -25,7 +25,7 @@ final class TextInputViewControllerTests: XCTestCase {
         
         let textFieldViewModel = MockTextFieldViewModel<InputType>()
         
-        let viewModel = MockTextInputViewModel<InputType>(textFieldViewModel: textFieldViewModel) { result in
+        let viewModel = MockTextInputViewModel<InputType> { result in
             self.didSetResult = [result]
         } appearAction: {
             self.screenDidAppear = true

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -128,7 +128,8 @@ loadResourceWithCallback() {
 
 Screen view controllers should generally inherit from ``BaseViewController`` instead of `UIViewController` unless the functionality of the screen needs to be intentionally different from standard screens.
 
-**To use:**
+#### To use:
+
 Once inheriting from ``BaseViewController`` and adding conformance to ``BaseViewModel`` to concrete view model, in the future do not add the following properties and methods to view model protocols:
 
 ```swift
@@ -141,14 +142,15 @@ Instead, when creating concrete implementations of view models, conform the conc
 
 As long as the view controller inherits from ``BaseViewController`` instead of `UIViewController`, these will be handled without any additional code.
 
-**Breaking change / migration**
+#### Breaking change / migration
+
 For screen patterns / view controllers in `GDSCommon` that have been migrated to inherit from ``BaseViewController``, concrete implementations of associated view models will need updating.
 
 To move to this new implementation, conform your concrete view models to ``BaseViewModel``. If there are any properties that are missing these should be added to conform to the protocol and the properties set accordingly.
 
 If there are other screens not within `GDSCommon`, it may be helpful to inherit from ``BaseViewController`` to gain the same benefits, but the time frame for rolling that out would be independent from the breaking changes introduced here and up to the individual code owners. The breaking changes described here are specifically relating to screens within `GDSCommon`.
 
-**Example**
+#### Example
 
 _BEFORE:_
 ```swift

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -122,6 +122,82 @@ loadResourceWithCallback() {
 
 ## Patterns
 
+### BaseViewController
+
+``BaseViewController`` inherits from `UIViewController`. ``BaseViewController`` includes the repetitive code that all screens should have to avoid repetition and reduce risk of missing important functionality and to make it easier to amend, or fix defects if they arise.
+
+Screen view controllers should generally inherit from ``BaseViewController`` instead of `UIViewController` unless the functionality of the screen needs to be intentionally different from standard screens.
+
+**To use:**
+Once inheriting from ``BaseViewController`` and adding conformance to ``BaseViewModel`` to concrete view model, in the future do not add the following properties and methods to view model protocols:
+
+```swift
+var rightBarButtonTitle: GDSLocalisedString? { get }
+var backButtonIsHidden: Bool { get }
+func didAppear()
+func didDismiss()
+```
+Instead, when creating concrete implementations of view models, conform the concrete implementations to the view model protocol _and_ to the ``BaseViewModel`` protocol. ``BaseViewModel`` includes the above properties and methods.
+
+As long as the view controller inherits from ``BaseViewController`` instead of `UIViewController`, these will be handled without any additional code.
+
+**Breaking change / migration**
+For screen patterns / view controllers in `GDSCommon` that have been migrated to inherit from ``BaseViewController``, concrete implementations of associated view models will need updating.
+
+To move to this new implementation, conform your concrete view models to ``BaseViewModel``. If there are any properties that are missing these should be added to conform to the protocol and the properties set accordingly.
+
+If there are other screens not within `GDSCommon`, it may be helpful to inherit from ``BaseViewController`` to gain the same benefits, but the time frame for rolling that out would be independent from the breaking changes introduced here and up to the individual code owners. The breaking changes described here are specifically relating to screens within `GDSCommon`.
+
+**Example**
+
+_BEFORE:_
+```swift
+public final class ModalInfoViewController: UIViewController {
+...
+    public init(viewModel: ModalInfoViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: "ModalInfoView", bundle: .module)
+    }
+...
+}
+
+public protocol ModalInfoViewModel {
+    var title: GDSLocalisedString { get }
+    var body: GDSLocalisedString { get }
+    var rightBarButtonTitle: GDSLocalisedString { get }
+
+    func didAppear()
+    func didDismiss()
+}
+```
+
+_AFTER:_
+```swift
+public final class ModalInfoViewController: BaseViewController {
+...
+    public init(viewModel: ModalInfoViewModel) {
+        self.viewModel = viewModel
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ModalInfoView", bundle: .module)
+    }
+...
+}
+
+public protocol ModalInfoViewModel {
+    var title: GDSLocalisedString { get }
+    var body: GDSLocalisedString { get }
+}
+
+// concrete view model within app:
+struct ConcreteModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
+    var title: GDSLocalisedString  = "title"
+    var body: GDSLocalisedString = "body"
+    var rightBarButtonTitle: GDSLocalisedString = "right bar button"
+
+    func didAppear() { }
+    func didDismiss() { }
+}
+```
+
 ### GDSInstructions
 This screen includes the following views:
 - `titleLabel` (type: `UILabel`)

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -142,55 +142,25 @@ Instead, when creating concrete implementations of view models, conform the conc
 
 As long as the view controller inherits from ``BaseViewController`` instead of `UIViewController`, these will be handled without any additional code.
 
-#### Breaking change / migration
-
-For screen patterns / view controllers in `GDSCommon` that have been migrated to inherit from ``BaseViewController``, concrete implementations of associated view models will need updating.
-
-To move to this new implementation, conform your concrete view models to ``BaseViewModel``. If there are any properties that are missing these should be added to conform to the protocol and the properties set accordingly.
-
-If there are other screens not within `GDSCommon`, it may be helpful to inherit from ``BaseViewController`` to gain the same benefits, but the time frame for rolling that out would be independent from the breaking changes introduced here and up to the individual code owners. The breaking changes described here are specifically relating to screens within `GDSCommon`.
-
 #### Example
 
-_BEFORE:_
 ```swift
-public final class ModalInfoViewController: UIViewController {
+public final class ExampleViewController: BaseViewController {
 ...
-    public init(viewModel: ModalInfoViewModel) {
+    public init(viewModel: ExampleInfoViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "ModalInfoView", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ExampleInfoView", bundle: .module)
     }
 ...
 }
 
-public protocol ModalInfoViewModel {
-    var title: GDSLocalisedString { get }
-    var body: GDSLocalisedString { get }
-    var rightBarButtonTitle: GDSLocalisedString { get }
-
-    func didAppear()
-    func didDismiss()
-}
-```
-
-_AFTER:_
-```swift
-public final class ModalInfoViewController: BaseViewController {
-...
-    public init(viewModel: ModalInfoViewModel) {
-        self.viewModel = viewModel
-        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ModalInfoView", bundle: .module)
-    }
-...
-}
-
-public protocol ModalInfoViewModel {
+public protocol ExampleInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
 }
 
 // concrete view model within app:
-struct ConcreteModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
+struct ConcreteModalInfoViewModel: ExampleInfoViewModel, BaseViewModel {
     var title: GDSLocalisedString  = "title"
     var body: GDSLocalisedString = "body"
     var rightBarButtonTitle: GDSLocalisedString = "right bar button"

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -4,6 +4,8 @@ import UIKit
 /// The view controller is configured with a  `BaseViewModel`
 /// For the functionality of `BaseViewController` to work, the concrete implementation of
 /// view model must conform to `BaseViewModel`.
+/// Screen view controllers should generally inherit from ``BaseViewController`` instead of `UIViewController`
+/// unless the functionality of the screen needs to be intentionally different from standard screens.
 public class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
     init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+public protocol BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString? { get }
+    
+    func didAppear()
+    func didDismiss()
+}
+
+public class BaseViewController: UIViewController {
+    private let viewModel: BaseViewModel?
+    
+    init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
+        self.viewModel = viewModel
+        super.init(nibName: nibName, bundle: bundle)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if viewModel?.rightBarButtonTitle != nil {
+            self.navigationItem.rightBarButtonItem = .init(title: viewModel?.rightBarButtonTitle?.value,
+                                                           style: .done,
+                                                           target: self,
+                                                           action: #selector(dismissScreen))
+        }
+    }
+    
+    @objc private func dismissScreen() {
+        self.dismiss(animated: true)
+        
+        viewModel?.didDismiss()
+    }
+}
+

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -26,6 +26,11 @@ public class BaseViewController: UIViewController {
         }
     }
     
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
+    }
+    
     @objc private func dismissScreen() {
         self.dismiss(animated: true)
         

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -6,14 +6,14 @@ import UIKit
 /// view model must conform to `BaseViewModel`.
 /// Screen view controllers should generally inherit from ``BaseViewController`` instead of `UIViewController`
 /// unless the functionality of the screen needs to be intentionally different from standard screens.
-public class BaseViewController: UIViewController {
+open class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
     init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
         self.viewModel = viewModel
         super.init(nibName: nibName, bundle: bundle)
     }
     
-    required init?(coder: NSCoder) {
+    required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -1,12 +1,5 @@
 import UIKit
 
-public protocol BaseViewModel {
-    var rightBarButtonTitle: GDSLocalisedString? { get }
-    
-    func didAppear()
-    func didDismiss()
-}
-
 public class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
     
@@ -22,6 +15,10 @@ public class BaseViewController: UIViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
+        setBackButtonTitle(isHidden: viewModel?.backButtonIsHidden ?? false)
+        
         if viewModel?.rightBarButtonTitle != nil {
             self.navigationItem.rightBarButtonItem = .init(title: viewModel?.rightBarButtonTitle?.value,
                                                            style: .done,
@@ -36,4 +33,3 @@ public class BaseViewController: UIViewController {
         viewModel?.didDismiss()
     }
 }
-

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 
 public class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
-    
     init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
         self.viewModel = viewModel
         super.init(nibName: nibName, bundle: bundle)

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+/// `BaseViewController` provides standard lifecycle functionality for other view controllers to inherit from
+/// The view controller is configured with a  `BaseViewModel`
+/// For the functionality of `BaseViewController` to work, the concrete implementation of
+/// view model must conform to `BaseViewModel`.
 public class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
     init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString? { get }
+    var backButtonIsHidden: Bool { get }
+    
+    func didAppear()
+    func didDismiss()
+}

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerScreenViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerScreenViewModel.swift
@@ -10,14 +10,10 @@ import UIKit
 /// include logging screen analytics or loading content from an endpoint for example.
 /// The `result` closure returns the selected date.
 @available(iOS 13.4, *)
-public protocol DatePickerScreenViewModel {
+public protocol DatePickerScreenViewModel: BaseViewModel {
     var title: GDSLocalisedString { get }
     var datePickerViewModel: DatePickerViewModel { get set }
     var datePickerFooter: String? { get }
     var buttonViewModel: ButtonViewModel { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
     var result: (Date) -> Void { get }
-    
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerScreenViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerScreenViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 /// include logging screen analytics or loading content from an endpoint for example.
 /// The `result` closure returns the selected date.
 @available(iOS 13.4, *)
-public protocol DatePickerScreenViewModel: BaseViewModel {
+public protocol DatePickerScreenViewModel {
     var title: GDSLocalisedString { get }
     var datePickerViewModel: DatePickerViewModel { get set }
     var datePickerFooter: String? { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 /// DatePicker screen displays a standard iOS date picker in a scrollview with a bold LargeTitle above
 /// and a single CTA button at the button of the screen.
 @available(iOS 13.4, *)
-public final class DatePickerScreenViewController: UIViewController {
+public final class DatePickerScreenViewController: BaseViewController {
     public override var nibName: String? { "DatePicker" }
     
     public var viewModel: DatePickerScreenViewModel
@@ -15,7 +15,7 @@ public final class DatePickerScreenViewController: UIViewController {
     
     public init(viewModel: DatePickerScreenViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "DatePicker", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "DatePicker", bundle: .module)
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -23,13 +23,6 @@ public final class DatePickerScreenViewController: UIViewController {
         
         if viewModel.datePickerViewModel.selectedDate == nil {
             primaryButton.isEnabled = false
-        }
-        
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
         }
     }
     
@@ -92,11 +85,5 @@ public final class DatePickerScreenViewController: UIViewController {
         guard let selectedDate = viewModel.datePickerViewModel.selectedDate else { return }
         viewModel.result(selectedDate)
         viewModel.buttonViewModel.action()
-    }
-    
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/DatePicker/DatePickerViewController.swift
@@ -15,7 +15,7 @@ public final class DatePickerScreenViewController: BaseViewController {
     
     public init(viewModel: DatePickerScreenViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "DatePicker", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "DatePicker", bundle: .module)
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -24,12 +24,6 @@ public final class DatePickerScreenViewController: BaseViewController {
         if viewModel.datePickerViewModel.selectedDate == nil {
             primaryButton.isEnabled = false
         }
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        viewModel.didAppear()
     }
     
     @IBOutlet private var titleLabel: UILabel! {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -37,18 +37,8 @@ public class GDSInstructionsViewController: BaseViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
-        
-//        setBackButtonTitle()
-        
-//        if viewModel.rightBarButtonTitle != nil {
-//            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-//                                                           style: .done,
-//                                                           target: self,
-//                                                           action: #selector(dismissScreen))
-//        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -123,10 +113,4 @@ public class GDSInstructionsViewController: BaseViewController {
             buttonViewModel.action()
         }
     }
-    
-//    @objc private func dismissScreen() {
-//        self.dismiss(animated: true)
-//        
-//        viewModel.didDismiss()
-//    }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -41,11 +41,6 @@ public class GDSInstructionsViewController: BaseViewController {
         primaryButton.isLoading = false
     }
     
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
-    }
-    
     /// Title label: `UILabel`
     @IBOutlet private var titleLabel: UILabel! {
         didSet {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -28,7 +28,7 @@ public class GDSInstructionsViewController: BaseViewController {
     public init(viewModel: GDSInstructionsViewModel
     ) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "GDSInstructions", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "GDSInstructions", bundle: .module)
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -19,7 +19,7 @@ import UIKit
 ///  The `primaryButton` is within a
 ///  `UIStackView` constrained to the bottom of the screen. This is the main
 ///   Call To Action (CTA) on this screen.
-public class GDSInstructionsViewController: UIViewController {
+public class GDSInstructionsViewController: BaseViewController {
     private let viewModel: GDSInstructionsViewModel
     
     /// Initialiser for the `GDSInstructions` view controller.
@@ -28,7 +28,7 @@ public class GDSInstructionsViewController: UIViewController {
     public init(viewModel: GDSInstructionsViewModel
     ) {
         self.viewModel = viewModel
-        super.init(nibName: "GDSInstructions", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "GDSInstructions", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
@@ -40,14 +40,15 @@ public class GDSInstructionsViewController: UIViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
-        setBackButtonTitle()
         
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
-        }
+//        setBackButtonTitle()
+        
+//        if viewModel.rightBarButtonTitle != nil {
+//            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
+//                                                           style: .done,
+//                                                           target: self,
+//                                                           action: #selector(dismissScreen))
+//        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -123,9 +124,9 @@ public class GDSInstructionsViewController: UIViewController {
         }
     }
     
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
-    }
+//    @objc private func dismissScreen() {
+//        self.dismiss(animated: true)
+//        
+//        viewModel.didDismiss()
+//    }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -17,7 +17,7 @@ import UIKit
 /// for other code such as making an API call.
 /// If `rightBarButtonTitle` is `nil` then the navigation item right bar button is hidden
 /// Otherwise, it is set to the title property and the action is set to the `didDismiss()` action.
-public protocol GDSInstructionsViewModel {
+public protocol GDSInstructionsViewModel: BaseViewModel {
     var title: GDSLocalisedString { get }
     var body: String { get }
     var rightBarButtonTitle: GDSLocalisedString? { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -10,21 +10,10 @@ import UIKit
 ///
 /// `childView` is added at the bottom of the `stackView` that contains the `title` and
 /// `body`. Because it is of type `UIView` the kind of view that can be added here is very flexible.
-///
-/// Additionally there is a protocol method `didAppear()` which should be used
-/// for any code that needs to be performed when the screen appears.
-/// For example, this might include tracking an analytics screen view, but it could be used
-/// for other code such as making an API call.
-/// If `rightBarButtonTitle` is `nil` then the navigation item right bar button is hidden
-/// Otherwise, it is set to the title property and the action is set to the `didDismiss()` action.
 public protocol GDSInstructionsViewModel {
     var title: GDSLocalisedString { get }
     var body: String { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
     var childView: UIView { get }
     var buttonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
-    
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -17,7 +17,7 @@ import UIKit
 /// for other code such as making an API call.
 /// If `rightBarButtonTitle` is `nil` then the navigation item right bar button is hidden
 /// Otherwise, it is set to the title property and the action is set to the `didDismiss()` action.
-public protocol GDSInstructionsViewModel: BaseViewModel {
+public protocol GDSInstructionsViewModel {
     var title: GDSLocalisedString { get }
     var body: String { get }
     var rightBarButtonTitle: GDSLocalisedString? { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewController.swift
@@ -23,12 +23,7 @@ public final class IconScreenViewController: BaseViewController {
     /// - Parameter viewModel: `IconScreenViewModel`
     public init(viewModel: IconScreenViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "IconScreenView", bundle: .module)
-    }
-
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "IconScreenView", bundle: .module)
     }
     
     /// Image view: ``UIImageView``

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 /// This screen allows for additional subviews to be added below a top stack view
 /// containing an icon, title and subtitle.
 /// Typically the subviews would be further `UIStackView`s, a good implementation of which sits within this same directory, `OptionView`
-public final class IconScreenViewController: UIViewController {
+public final class IconScreenViewController: BaseViewController {
     public override var nibName: String? { "IconScreenView" }
     
     public let viewModel: IconScreenViewModel
@@ -21,11 +21,9 @@ public final class IconScreenViewController: UIViewController {
     /// Initialiser for the `IconScreenView` view controller.
     /// Requires a single parameter.
     /// - Parameter viewModel: `IconScreenViewModel`
-    public init(viewModel: IconScreenViewModel,
-                hidesBackButton: Bool = false) {
+    public init(viewModel: IconScreenViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "IconScreenView", bundle: .module)
-        self.navigationItem.hidesBackButton = hidesBackButton
+        super.init(viewModel: viewModel, nibName: "IconScreenView", bundle: .module)
     }
 
     public override func viewDidAppear(_ animated: Bool) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewModel.swift
@@ -10,11 +10,9 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol IconScreenViewModel {
+public protocol IconScreenViewModel: BaseViewModel {
     var imageName: String { get }
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var childViews: [UIView] { get }
-    
-    func didAppear()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IconScreenView/IconScreenViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol IconScreenViewModel: BaseViewModel {
+public protocol IconScreenViewModel {
     var imageName: String { get }
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -26,15 +26,9 @@ public final class InstructionsWithImageViewController: BaseViewController {
     /// - Parameter viewModel: `InstructionsWithImageViewModel`
     public init(viewModel: InstructionsWithImageViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "InstructionsWithImage", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "InstructionsWithImage", bundle: .module)
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        viewModel.didAppear()
-    }
-    
     /// Title label: ``UILabel``
     @IBOutlet private var titleLabel: UILabel! {
         didSet {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 /// in turn within a `UIScrollView`. The `primaryButton` is within a
 /// `UIStackView` constrained to the bottom of the screen. This is the main
 /// Call To Action (CTA) on this screen.
-public final class InstructionsWithImageViewController: UIViewController {
+public final class InstructionsWithImageViewController: BaseViewController {
     public override var nibName: String? { "InstructionsWithImage" }
     
     public let viewModel: InstructionsWithImageViewModel
@@ -26,21 +26,9 @@ public final class InstructionsWithImageViewController: UIViewController {
     /// - Parameter viewModel: `InstructionsWithImageViewModel`
     public init(viewModel: InstructionsWithImageViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "InstructionsWithImage", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "InstructionsWithImage", bundle: .module)
     }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
 
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
-        }
-    }
-    
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -138,11 +126,5 @@ public final class InstructionsWithImageViewController: UIViewController {
         if let buttonViewModel = viewModel.secondaryButtonViewModel {
             buttonViewModel.action()
         }
-    }
-    
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -11,7 +11,7 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol InstructionsWithImageViewModel: BaseViewModel {
+public protocol InstructionsWithImageViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }
     var image: UIImage { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -6,11 +6,6 @@ import UIKit
 /// - `image` type is `UIImage`
 /// - `warningButtonViewModel` type is ``ButtonViewModel``?
 /// - `primaryButtonViewModel` type is ``ButtonViewModel``
-///
-/// Additionally there is a protocol method `didAppear()` which should be used
-/// for any code that needs to be performed when the screen appears.
-/// For example, this might include tracking an analytics screen view, but it could be used
-/// for other code such as making an API call.
 public protocol InstructionsWithImageViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -11,15 +11,11 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol InstructionsWithImageViewModel {
+public protocol InstructionsWithImageViewModel: BaseViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }
     var image: UIImage { get }
     var warningButtonViewModel: ButtonViewModel? { get }
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
-
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
@@ -17,7 +17,7 @@ public final class IntroViewController: BaseViewController {
 
     public init(viewModel: IntroViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "IntroView", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "IntroView", bundle: .module)
     }
     
     @available(*, unavailable, renamed: "init(coordinator:)")
@@ -52,11 +52,6 @@ public final class IntroViewController: BaseViewController {
             introButton.setTitle(viewModel.introButtonViewModel.title, for: .normal)
             introButton.accessibilityIdentifier = "intro-button"
         }
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
     }
 
     @IBAction private func didTapContinueButton() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 /// - Back button via setting the `hideBackButton` boolean property on the view controller
 /// The `viewWillAppear` lifecycle event triggers the `didAppear` method in the viewModel.
 /// The `introButton`'s action is set from the ``ButtonViewModel`` in the viewModel.
-public final class IntroViewController: UIViewController {
+public final class IntroViewController: BaseViewController {
     public override var nibName: String? { "IntroView" }
     
     private let viewModel: IntroViewModel
 
     public init(viewModel: IntroViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "IntroView", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "IntroView", bundle: .module)
     }
     
     @available(*, unavailable, renamed: "init(coordinator:)")
@@ -54,10 +54,8 @@ public final class IntroViewController: UIViewController {
         }
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        setBackButtonTitle()
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         viewModel.didAppear()
     }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewModel.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Protocol for the view model required to initilise a ``IntroViewController``
-public protocol IntroViewModel: BaseViewModel {
+public protocol IntroViewModel {
     var image: UIImage { get }
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewModel.swift
@@ -1,11 +1,9 @@
 import UIKit
 
 /// Protocol for the view model required to initilise a ``IntroViewController``
-public protocol IntroViewModel {
+public protocol IntroViewModel: BaseViewModel {
     var image: UIImage { get }
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var introButtonViewModel: ButtonViewModel { get }
-    
-    func didAppear()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -20,7 +20,7 @@ public final class ListOptionsViewController: BaseViewController {
 
     public init(viewModel: ListOptionsViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "ListOptions", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ListOptions", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
@@ -45,12 +45,7 @@ public final class ListOptionsViewController: BaseViewController {
         super.viewWillLayoutSubviews()
         tableViewList.redraw()
     }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
-    }
-    
+
     @IBOutlet private var titleLabel: UILabel! {
         didSet {
             titleLabel.text = viewModel.title.value

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -14,14 +14,14 @@ import UIKit
 /// The action can be customised by configuring the `didDismiss` method.
 /// `footerLabel` is configured separately from the `UITableView` to address some
 /// dynamic type issues with multi-line footers.
-public final class ListOptionsViewController: UIViewController {
+public final class ListOptionsViewController: BaseViewController {
     public override var nibName: String? { "ListOptions" }
     public let viewModel: ListOptionsViewModel
     public var hideBackButton: Bool = false
 
     public init(viewModel: ListOptionsViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "ListOptions", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "ListOptions", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
@@ -42,12 +42,12 @@ public final class ListOptionsViewController: UIViewController {
         super.viewWillAppear(animated)
         tableViewList.redraw()
         
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
-        }
+//        if viewModel.rightBarButtonTitle != nil {
+//            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
+//                                                           style: .done,
+//                                                           target: self,
+//                                                           action: #selector(dismissScreen))
+//        }
     }
     
     public override func viewWillLayoutSubviews() {
@@ -110,11 +110,11 @@ public final class ListOptionsViewController: UIViewController {
         viewModel.buttonViewModel.action()
     }
     
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
-    }
+//    @objc private func dismissScreen() {
+//        self.dismiss(animated: true)
+//        
+//        viewModel.didDismiss()
+//    }
 }
 
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -17,7 +17,6 @@ import UIKit
 public final class ListOptionsViewController: BaseViewController {
     public override var nibName: String? { "ListOptions" }
     public let viewModel: ListOptionsViewModel
-    public var hideBackButton: Bool = false
 
     public init(viewModel: ListOptionsViewModel) {
         self.viewModel = viewModel
@@ -35,19 +34,11 @@ public final class ListOptionsViewController: BaseViewController {
         tableViewList.dataSource = self
         tableViewList.delegate = self
         tableViewList.isScrollEnabled = false
-        setBackButtonTitle(isHidden: hideBackButton)
     }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableViewList.redraw()
-        
-//        if viewModel.rightBarButtonTitle != nil {
-//            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-//                                                           style: .done,
-//                                                           target: self,
-//                                                           action: #selector(dismissScreen))
-//        }
     }
     
     public override func viewWillLayoutSubviews() {
@@ -109,12 +100,6 @@ public final class ListOptionsViewController: BaseViewController {
         viewModel.resultAction(cell.gdsLocalisedString)
         viewModel.buttonViewModel.action()
     }
-    
-//    @objc private func dismissScreen() {
-//        self.dismiss(animated: true)
-//        
-//        viewModel.didDismiss()
-//    }
 }
 
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Protocol for the view model required to initilise a ``ListOptionsViewController``
-public protocol ListOptionsViewModel: BaseViewModel {
+public protocol ListOptionsViewModel {
     var title: GDSLocalisedString { get }
     var body: String? { get }
     var listRows: [GDSLocalisedString] { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
@@ -7,9 +7,5 @@ public protocol ListOptionsViewModel: BaseViewModel {
     var listRows: [GDSLocalisedString] { get }
     var listFooter: String? { get }
     var buttonViewModel: ButtonViewModel { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
     var resultAction: (GDSLocalisedString) -> Void { get }
-    
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Protocol for the view model required to initilise a ``ListOptionsViewController``
-public protocol ListOptionsViewModel {
+public protocol ListOptionsViewModel: BaseViewModel {
     var title: GDSLocalisedString { get }
     var body: String? { get }
     var listRows: [GDSLocalisedString] { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -18,16 +18,11 @@ public final class ModalInfoViewController: BaseViewController {
     /// - Parameter viewModel: `ModalInfoViewModel`
     public init(viewModel: ModalInfoViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "ModalInfoView", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ModalInfoView", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
     }
     
     @IBOutlet private var titleLabel: UILabel! {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 ///   with a title and body to present the information.
 ///   There is also configuration for a right `UIBarButtonItem` with an action
 ///   configurable in the `dismissModal()` method in the viewModel.
-public final class ModalInfoViewController: UIViewController {
+public final class ModalInfoViewController: BaseViewController {
     public override var nibName: String? { "ModalInfoView" }
     
     public let viewModel: ModalInfoViewModel
@@ -18,25 +18,15 @@ public final class ModalInfoViewController: UIViewController {
     /// - Parameter viewModel: `ModalInfoViewModel`
     public init(viewModel: ModalInfoViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "ModalInfoView", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "ModalInfoView", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle.value,
-                                                       style: .done,
-                                                       target: self,
-                                                       action: #selector(dismissModal))
-        self.navigationItem.hidesBackButton = true
-    }
-    
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
         viewModel.didAppear()
     }
     
@@ -58,11 +48,5 @@ public final class ModalInfoViewController: UIViewController {
             bodyLabel.textColor = .gdsGrey
             bodyLabel.accessibilityIdentifier = "bodyLabel"
         }
-    }
-    
-    @objc private func dismissModal() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -8,11 +8,7 @@ import UIKit
 /// for any code that needs to be performed when the screen appears or is dismissed.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol ModalInfoViewModel {
+public protocol ModalInfoViewModel: BaseViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
-    var rightBarButtonTitle: GDSLocalisedString { get }
-    
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -8,7 +8,7 @@ import UIKit
 /// for any code that needs to be performed when the screen appears or is dismissed.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
-public protocol ModalInfoViewModel: BaseViewModel {
+public protocol ModalInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -3,11 +3,6 @@ import UIKit
 /// View model for the `ModalInfoViewController`
 /// - `title` type is ``GDSLocalisedString``
 /// - `body` type is ``GDSLocalisedString``
-///
-/// Additionally there are protocol methods for `didAppear()` and `didDismiss()` which should be used
-/// for any code that needs to be performed when the screen appears or is dismissed.
-/// For example, this might include tracking an analytics screen view, but it could be used
-/// for other code such as making an API call.
 public protocol ModalInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewController.swift
@@ -50,7 +50,9 @@ public final class ResultsViewController: BaseViewController {
     @IBAction private func didTapDoneButton() {
         resultsButton.isLoading = true
         viewModel.resultsButtonViewModel.action()
-        viewModel.didDismiss()
+        if let viewModel = viewModel as? BaseViewModel {
+            viewModel.didDismiss()
+        }
         resultsButton.isLoading = false
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewController.swift
@@ -1,14 +1,14 @@
 import UIKit
 
 /// View controller for `ResultsView` screen.
-public final class ResultsViewController: UIViewController {
+public final class ResultsViewController: BaseViewController {
     public override var nibName: String? { "ResultsView" }
     
     public let viewModel: ResultsViewModel
 
     public init(viewModel: ResultsViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "ResultsView", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "ResultsView", bundle: .module)
     }
     
     required init?(coder: NSCoder) {
@@ -45,11 +45,6 @@ public final class ResultsViewController: UIViewController {
             resultsButton.setTitle(viewModel.resultsButtonViewModel.title, for: .normal)
             resultsButton.accessibilityIdentifier = "results-button"
         }
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
     }
 
     @IBAction private func didTapDoneButton() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Results/ResultsViewModel.swift
@@ -6,7 +6,4 @@ public protocol ResultsViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString? { get }
     var resultsButtonViewModel: ButtonViewModel { get }
-    
-    func didAppear()
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/QRScanningViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/QRScanningViewModel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol QRScanningViewModel: BaseViewModel {
+public protocol QRScanningViewModel {
     var title: String { get }
     var instructionText: String { get }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/QRScanningViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/QRScanningViewModel.swift
@@ -1,10 +1,8 @@
 import UIKit
 
-public protocol QRScanningViewModel {
+public protocol QRScanningViewModel: BaseViewModel {
     var title: String { get }
     var instructionText: String { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
     
     func didScan(value: String, in view: UIView) async
-    func didDismiss()
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -14,7 +14,7 @@ import Vision
 ///
 ///  The `instructionsLabel` and `cameraView` are within `view`. The view controller adds the `childView`
 
-public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSession>: UIViewController,
+public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSession>: BaseViewController,
                                                                                      AVCaptureVideoDataOutputSampleBufferDelegate {
     private let captureDevice: any CaptureDevice.Type
     let captureSession: CaptureSession
@@ -56,7 +56,7 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         self.captureDevice = captureDevice
         self.captureSession = captureSession
         self.previewLayer = captureSession.layer
-        super.init(nibName: "Scanner", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "Scanner", bundle: .module)
         self.barcodeRequest = requestType.init(completionHandler: detectedBarcode(_:_:))
     }
     
@@ -80,13 +80,6 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         startAnimation()
-        
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
-        }
     }
     
     private func updateRegionOfInterest() {
@@ -144,12 +137,6 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         } catch {
             preconditionFailure("Error with capturing output")
         }
-    }
-    
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        
-        viewModel.didDismiss()
     }
 }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -56,7 +56,7 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         self.captureDevice = captureDevice
         self.captureSession = captureSession
         self.previewLayer = captureSession.layer
-        super.init(viewModel: viewModel, nibName: "Scanner", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "Scanner", bundle: .module)
         self.barcodeRequest = requestType.init(completionHandler: detectedBarcode(_:_:))
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInput.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInput.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" restorationIdentifier="GDSInstructions" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" restorationIdentifier="TextInput" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
@@ -23,7 +23,7 @@ public final class TextInputViewController<InputType>: BaseViewController, UITex
     
     public init(viewModel: any TextInputViewModel) {
         self.viewModel = viewModel
-        super.init(viewModel: viewModel, nibName: "TextInput", bundle: .module)
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "TextInput", bundle: .module)
     }
     
     public override func viewDidLoad() {
@@ -36,11 +36,6 @@ public final class TextInputViewController<InputType>: BaseViewController, UITex
         if let keyboardDoneButton = viewModel.textFieldViewModel.keyboardDoneButton {
             barButton(keyboardDoneButton)
         }
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.didAppear()
     }
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
@@ -12,7 +12,7 @@ public protocol TextInputView {
 /// allows concrete implementations of `TextFieldViewModel` protocol to implement validation methods to
 /// validate and constrain the input of the text field.
 /// The validator method is called on every change of the text field.
-public final class TextInputViewController<InputType>: UIViewController, UITextFieldDelegate, TextInputView {
+public final class TextInputViewController<InputType>: BaseViewController, UITextFieldDelegate, TextInputView {
     public override var nibName: String? { "TextInput" }
     
     public var viewModel: any TextInputViewModel
@@ -23,7 +23,7 @@ public final class TextInputViewController<InputType>: UIViewController, UITextF
     
     public init(viewModel: any TextInputViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: "TextInput", bundle: .module)
+        super.init(viewModel: viewModel, nibName: "TextInput", bundle: .module)
     }
     
     public override func viewDidLoad() {
@@ -35,17 +35,6 @@ public final class TextInputViewController<InputType>: UIViewController, UITextF
         
         if let keyboardDoneButton = viewModel.textFieldViewModel.keyboardDoneButton {
             barButton(keyboardDoneButton)
-        }
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        if viewModel.rightBarButtonTitle != nil {
-            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(dismissScreen))
         }
     }
     
@@ -135,10 +124,5 @@ public final class TextInputViewController<InputType>: UIViewController, UITextF
     
     @objc func dismissKeyboard() {
         textField.endEditing(true)
-    }
-    
-    @objc private func dismissScreen() {
-        self.dismiss(animated: true)
-        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// `TextInputViewModel` protocol to be used with `TextInputViewController`
-public protocol TextInputViewModel: BaseViewModel {
+public protocol TextInputViewModel {
     associatedtype InputType: LosslessStringConvertible
     
     var title: GDSLocalisedString { get }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewModel.swift
@@ -2,19 +2,15 @@ import Foundation
 import UIKit
 
 /// `TextInputViewModel` protocol to be used with `TextInputViewController`
-public protocol TextInputViewModel {
+public protocol TextInputViewModel: BaseViewModel {
     associatedtype InputType: LosslessStringConvertible
     
     var title: GDSLocalisedString { get }
     var textFieldFooter: String? { get }
     var buttonViewModel: ButtonViewModel { get }
-    var rightBarButtonTitle: GDSLocalisedString? { get }
     var textFieldViewModel: TextFieldViewModel { get }
     
     var result: (InputType) -> Void { get }
-    
-    func didAppear()
-    func didDismiss()
 }
 
 extension TextInputViewModel {

--- a/Tests/GDSCommonTests/ComponentTests/Mocks/MockTextInputViewModel.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Mocks/MockTextInputViewModel.swift
@@ -11,6 +11,7 @@ struct MockTextInputViewModel<InputType>: TextInputViewModel {
         print("button was tapped")
     }
     let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
+    var backButtonIsHidden: Bool = false
     let result: (Bool) -> Void
     
     let appearAction: () -> Void


### PR DESCRIPTION
# Adding base view controller to reduce duplication

There were some repetitive blocks of code and protocol conformances across numerous screen patterns that were creating a risk of defect and additional work should a change be required.

This PR creates a `BaseViewController` that inherits from `UIViewController`. The `BaseViewController` includes all the repetitive code and code that all screens should have. 

All screens then inherit from the `BaseViewController` instead of `UIViewController`. 

**To use:**

For most screens, in the future we should **not** need to add the following properties and methods to view model protocols:

* var rightBarButtonTitle: GDSLocalisedString? { get }
* var backButtonIsHidden: Bool { get }
* func didAppear()
* func didDismiss()

Instead, when creating concrete implementations of your view models, you should conform the concrete implementations to your view model protocol and to the `BaseViewModel` protocol. `BaseViewModel` includes the above properties and methods.

As long as your view controller inherits from `BaseViewController` instead of `UIViewController`, handling of these will be dealt with without any additional effort or code.

**Breaking change / migration**
To move to this new implementation, you should add the protocol conformance to `BaseViewModel` to concrete screen view model implementations where prompted. If there are any properties that are missing these should be added to conform to the protocol and the properties set accordingly.

If there are other screens within separate repos, it may be beneficial to inherit from `BaseViewController` and `BaseViewModel` to help reduce code duplication, but the time frame for rolling that out would be independent from the breaking changes introduced here. The breaking changes are specifically relating to screens within `GDSCommon`


**Example**

_BEFORE:_
```swift
public final class ModalInfoViewController: UIViewController {
...
}

public protocol ModalInfoViewModel {
    var title: GDSLocalisedString { get }
    var body: GDSLocalisedString { get }
    var rightBarButtonTitle: GDSLocalisedString { get }

    func didAppear()
    func didDismiss()
}
```

_AFTER:_
```swift
public final class ModalInfoViewController: BaseViewController {
...
}

public protocol ModalInfoViewModel {
    var title: GDSLocalisedString { get }
    var body: GDSLocalisedString { get }
}

// concrete view model within app:
struct ConcreteModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
    var title: GDSLocalisedString  = "title"
    var body: GDSLocalisedString = "body"
    var rightBarButtonTitle: GDSLocalisedString = "right bar button"

    func didAppear() { }
    func didDismiss() { }
}
```

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
