### PR TITLE
fix: QR scanner has incorrect design

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
@@ -49,6 +49,8 @@ final class ScanningViewControllerTests: XCTestCase {
     func test_instructionsLabel() throws {
         try XCTAssertNotNil(sut.instructionsLabel)
         try XCTAssertEqual(sut.instructionsLabel.text, "QR Scanning instruction area, we can instruct the user from here")
+        try XCTAssertEqual(sut.instructionsLabel.textColor, .white)
+        try XCTAssertEqual(sut.instructionsLabel.font, .init(style: .body, weight: .bold))
     }
     
     func test_didDismiss() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanOverlayView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanOverlayView.swift
@@ -24,7 +24,6 @@ final class ScanOverlayView: UIView {
     
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
-        overlayLayer.fillColor = UIColor.systemBackground.cgColor
         overlayLayer.fillRule = .evenOdd
         overlayLayer.opacity = 0.5
         layer.addSublayer(overlayLayer)

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -30,6 +30,8 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         didSet {
             instructionsLabel.accessibilityIdentifier = "instructionsLabel"
             instructionsLabel.text = viewModel.instructionText
+            instructionsLabel.font = .init(style: .body, weight: .bold)
+            instructionsLabel.textColor = .white
         }
     }
     

--- a/Tests/GDSCommonTests/ScanOverlayViewTests.swift
+++ b/Tests/GDSCommonTests/ScanOverlayViewTests.swift
@@ -36,7 +36,6 @@ extension ScanOverlayViewTests {
     func testWillMoveToView() {
         parentView.addSubview(sut)
         
-        XCTAssertEqual(sut.overlayLayer.fillColor, UIColor.systemBackground.cgColor)
         XCTAssertEqual(sut.overlayLayer.fillRule, .evenOdd)
         XCTAssertEqual(sut.overlayLayer.opacity, 0.5)
         XCTAssertTrue(sut.layer.sublayers?.contains(sut.overlayLayer) ?? false)


### PR DESCRIPTION
# DCMAW-7368: QR scanner has incorrect design in light mode

This PR aims to remove the white overlay that appears on the QR code scanner page. The text has also been changed to appear bold and white in dark and light mode.
This PR also contains the fix for [DCMAW-7370](https://govukverify.atlassian.net/browse/DCMAW-7370).

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`


[DCMAW-7370]: https://govukverify.atlassian.net/browse/DCMAW-7370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ