### PR TITLE
fix: change access control on `BaseViewController` init to be public

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -8,7 +8,8 @@ import UIKit
 /// unless the functionality of the screen needs to be intentionally different from standard screens.
 open class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
-    init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
+    
+    public init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
         self.viewModel = viewModel
         super.init(nibName: nibName, bundle: bundle)
     }


### PR DESCRIPTION
# GOVAPP-220: `BaseViewController` init needs to be public

In order to initialise the `BaseViewController` and therefore use outside of `GDSCommon` the init needs to be `public`.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
   ~- [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
