### PR TITLE
fix: allowing error view model to be read outside the package

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSError/GDSErrorViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     
-    private(set) var viewModel: GDSErrorViewModel
+    public private(set) var viewModel: GDSErrorViewModel
 
     public init(viewModel: GDSErrorViewModel) {
         self.viewModel = viewModel

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSError/GDSErrorViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     
-    private let viewModel: GDSErrorViewModel
+    private(set) var viewModel: GDSErrorViewModel
 
     public init(viewModel: GDSErrorViewModel) {
         self.viewModel = viewModel


### PR DESCRIPTION
# fix: allowing error view model to be read outside the package

The error view controller's view model property is private and therefore can't be tested outside the package. This is needed for testing our project code to tell which error screens are shown.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code ~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
