### PR TITLE
fix: adding `@MainActor` to do VoiceOverFocus on main queue

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -37,11 +37,11 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
-        
-        if let screen = self as? VoiceOverFocus {
-            UIAccessibility.post(notification: .screenChanged,
-                                 argument: screen.initialVoiceOverView)
-        }
+//        
+//        if let screen = self as? VoiceOverFocus {
+//            UIAccessibility.post(notification: .screenChanged,
+//                                 argument: screen.initialVoiceOverView)
+//        }
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
@@ -56,9 +56,11 @@ open class BaseViewController: UIViewController {
         super.viewDidAppear(animated)
         viewModel?.didAppear()
         
-        if let screen = self as? VoiceOverFocus {
-            UIAccessibility.post(notification: .screenChanged,
-                                 argument: screen.initialVoiceOverView)
+        Task { @MainActor in
+            if let screen = self as? VoiceOverFocus {
+                UIAccessibility.post(notification: .screenChanged,
+                                     argument: screen.initialVoiceOverView)
+            }
         }
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -20,7 +20,7 @@ open class BaseViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        UIAccessibility.post(notification: .screenChanged,
+        UIAccessibility.post(notification: .resumeAssistiveTechnology,
                                  argument: nil)
     }
     
@@ -39,7 +39,7 @@ open class BaseViewController: UIViewController {
         }
         
         if let screen = self as? VoiceOverFocus {
-            UIAccessibility.post(notification: .layoutChanged,
+            UIAccessibility.post(notification: .screenChanged,
                                  argument: screen.initialVoiceOverView)
         }
     }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -31,20 +31,34 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
+        
+        UIAccessibility.post(notification: .screenChanged,
+                                 argument: nil)
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        UIAccessibility.post(notification: .screenChanged,
+                                 argument: nil)
     }
     
     public override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         
-        if let screen = self as? VoiceOverFocus {
-            UIAccessibility.post(notification: .screenChanged,
-                                 argument: screen.initialVoiceOverView)
-        }
+//        if let screen = self as? VoiceOverFocus {
+//            UIAccessibility.post(notification: .screenChanged,
+//                                 argument: screen.initialVoiceOverView)
+//        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel?.didAppear()
+        
+        if let screen = self as? VoiceOverFocus {
+            UIAccessibility.post(notification: .screenChanged,
+                                 argument: screen.initialVoiceOverView)
+        }
     }
     
     @objc private func dismissScreen() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -18,12 +18,6 @@ open class BaseViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-//        UIAccessibility.post(notification: .resumeAssistiveTechnology,
-//                                 argument: nil)
-    }
-    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -37,15 +31,6 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
-//        
-//        if let screen = self as? VoiceOverFocus {
-//            UIAccessibility.post(notification: .screenChanged,
-//                                 argument: screen.initialVoiceOverView)
-//        }
-    }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
     }
     
     public override func viewIsAppearing(_ animated: Bool) {
@@ -66,7 +51,6 @@ open class BaseViewController: UIViewController {
     
     @objc private func dismissScreen() {
         self.dismiss(animated: true)
-        
         viewModel?.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -20,8 +20,8 @@ open class BaseViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        UIAccessibility.post(notification: .resumeAssistiveTechnology,
-                                 argument: nil)
+//        UIAccessibility.post(notification: .resumeAssistiveTechnology,
+//                                 argument: nil)
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -52,11 +52,12 @@ open class BaseViewController: UIViewController {
         super.viewIsAppearing(animated)
     }
     
+    @MainActor
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel?.didAppear()
         
-        Task { @MainActor in
+        Task {
             if let screen = self as? VoiceOverFocus {
                 UIAccessibility.post(notification: .screenChanged,
                                      argument: screen.initialVoiceOverView)

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -50,19 +50,18 @@ open class BaseViewController: UIViewController {
     
     public override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
-    }
-    
-    @MainActor
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel?.didAppear()
         
-        Task {
+        Task { @MainActor in
             if let screen = self as? VoiceOverFocus {
                 UIAccessibility.post(notification: .screenChanged,
                                      argument: screen.initialVoiceOverView)
             }
         }
+    }
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
     }
     
     @objc private func dismissScreen() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -32,23 +32,23 @@ open class BaseViewController: UIViewController {
                                                            action: #selector(dismissScreen))
         }
         
-        UIAccessibility.post(notification: .screenChanged,
+        UIAccessibility.post(notification: .layoutChanged,
                                  argument: nil)
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        UIAccessibility.post(notification: .screenChanged,
+        UIAccessibility.post(notification: .layoutChanged,
                                  argument: nil)
     }
     
     public override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         
-//        if let screen = self as? VoiceOverFocus {
-//            UIAccessibility.post(notification: .screenChanged,
-//                                 argument: screen.initialVoiceOverView)
-//        }
+        if let screen = self as? VoiceOverFocus {
+            UIAccessibility.post(notification: .screenChanged,
+                                 argument: screen.initialVoiceOverView)
+        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -39,7 +39,7 @@ open class BaseViewController: UIViewController {
         }
         
         if let screen = self as? VoiceOverFocus {
-            UIAccessibility.post(notification: .screenChanged,
+            UIAccessibility.post(notification: .layoutChanged,
                                  argument: screen.initialVoiceOverView)
         }
     }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -18,6 +18,12 @@ open class BaseViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        UIAccessibility.post(notification: .screenChanged,
+                                 argument: nil)
+    }
+    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -32,23 +38,18 @@ open class BaseViewController: UIViewController {
                                                            action: #selector(dismissScreen))
         }
         
-        UIAccessibility.post(notification: .layoutChanged,
-                                 argument: nil)
-    }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        UIAccessibility.post(notification: .layoutChanged,
-                                 argument: nil)
-    }
-    
-    public override func viewIsAppearing(_ animated: Bool) {
-        super.viewIsAppearing(animated)
-        
         if let screen = self as? VoiceOverFocus {
             UIAccessibility.post(notification: .screenChanged,
                                  argument: screen.initialVoiceOverView)
         }
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+    
+    public override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
     }
     
     public override func viewDidAppear(_ animated: Bool) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -43,7 +43,8 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        tableViewList.selectRow(at: nil, animated: false, scrollPosition: .none)
+        guard let selectedIndex = tableViewList.indexPathForSelectedRow else { return }
+        tableViewList.deselectRow(at: selectedIndex, animated: false)
     }
     
     public override func viewWillLayoutSubviews() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -96,8 +96,7 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         viewModel.buttonViewModel.action()
         
         tableViewList.deselectRow(at: selectedIndex, animated: false)
-        UIAccessibility.post(notification: .screenChanged,
-                             argument: primaryButton)
+        UIAccessibility.post(notification: .pauseAssistiveTechnology, argument: nil)
     }
 }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -94,6 +94,8 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         
         viewModel.resultAction(cell.gdsLocalisedString)
         viewModel.buttonViewModel.action()
+        
+        tableViewList.deselectRow(at: selectedIndex, animated: false)
     }
 }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -45,6 +45,11 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         super.viewWillLayoutSubviews()
         tableViewList.redraw()
     }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        UIAccessibility.post(notification: .resumeAssistiveTechnology, argument: nil)
+    }
 
     @IBOutlet private(set) var titleLabel: UILabel! {
         didSet {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -41,6 +41,11 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         tableViewList.redraw()
     }
     
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        tableViewList.selectRow(at: nil, animated: false, scrollPosition: .none)
+    }
+    
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         tableViewList.redraw()
@@ -94,8 +99,6 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         
         viewModel.resultAction(cell.gdsLocalisedString)
         viewModel.buttonViewModel.action()
-        
-        tableViewList.deselectRow(at: selectedIndex, animated: false)
     }
 }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -45,11 +45,6 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         super.viewWillLayoutSubviews()
         tableViewList.redraw()
     }
-    
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        UIAccessibility.post(notification: .resumeAssistiveTechnology, argument: nil)
-    }
 
     @IBOutlet private(set) var titleLabel: UILabel! {
         didSet {
@@ -101,7 +96,6 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         viewModel.buttonViewModel.action()
         
         tableViewList.deselectRow(at: selectedIndex, animated: false)
-        UIAccessibility.post(notification: .pauseAssistiveTechnology, argument: nil)
     }
 }
 

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -41,12 +41,6 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         tableViewList.redraw()
     }
     
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        guard let selectedIndex = tableViewList.indexPathForSelectedRow else { return }
-        tableViewList.deselectRow(at: selectedIndex, animated: false)
-    }
-    
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         tableViewList.redraw()

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ListOptions/ListOptionsViewController.swift
@@ -96,6 +96,8 @@ public final class ListOptionsViewController: BaseViewController, TitledViewCont
         viewModel.buttonViewModel.action()
         
         tableViewList.deselectRow(at: selectedIndex, animated: false)
+        UIAccessibility.post(notification: .screenChanged,
+                             argument: primaryButton)
     }
 }
 


### PR DESCRIPTION
# GOVAPP-221: `VoiceOverFocus` should run on main queue

When this was tested locally it works reliably without `@MainActor` but the behaviour is unreliable when running from a remote package (it seems unexpected there would be a difference in behaviour)

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
