### PR TITLE
fix: move notification post to viewWillAppear temporarily

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,10 +17,10 @@ opt_in_rules:
 - sorted_imports
 - strong_iboutlet
 - private_action
+- private_outlet
 
 private_outlet:
   allow_private_set: true
-
 trailing_whitespace:
   ignores_empty_lines: true
 vertical_whitespace:
@@ -54,5 +54,5 @@ custom_rules:
         TODO comments must have a valid ticket number raised in Jira.
         Please use the format:
         // TODO: DCMAW-000
-    regex: "(?i)(todo(?!(.*dcmaw-\\d{2,})))"
+    regex: "(?i)(todo(?!(.*(dcmaw|govapp)-\\d{2,})))"
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
@@ -119,17 +119,6 @@ final class ScanningViewControllerTests: XCTestCase {
         XCTAssertTrue(output.sampleBufferDelegate === sut)
         XCTAssertTrue(output.sampleBufferCallbackQueue === sut.processingQueue)
     }
-    
-//    func testVoiceOverFocusElement() throws {
-//        sut.beginAppearanceTransition(true, animated: false)
-//        sut.endAppearanceTransition()
-//        
-////        let screen = try XCTUnwrap(sut as VoiceOverFocus)
-//        
-//        // should be instructions label because VC has no titleLabel
-////        let view = try XCTUnwrap(screen.initialVoiceOverView as? UILabel)
-//        XCTAssertEqual(view.text, "QR Scanning instruction area, we can instruct the user from here")
-//    }
 }
 
 extension ScanningViewController {

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
@@ -120,16 +120,16 @@ final class ScanningViewControllerTests: XCTestCase {
         XCTAssertTrue(output.sampleBufferCallbackQueue === sut.processingQueue)
     }
     
-    func testVoiceOverFocusElement() throws {
-        sut.beginAppearanceTransition(true, animated: false)
-        sut.endAppearanceTransition()
-        
-        let screen = try XCTUnwrap(sut as VoiceOverFocus)
-        
-        // should be instructions label because VC has no titleLabel
-        let view = try XCTUnwrap(screen.initialVoiceOverView as? UILabel)
-        XCTAssertEqual(view.text, "QR Scanning instruction area, we can instruct the user from here")
-    }
+//    func testVoiceOverFocusElement() throws {
+//        sut.beginAppearanceTransition(true, animated: false)
+//        sut.endAppearanceTransition()
+//        
+////        let screen = try XCTUnwrap(sut as VoiceOverFocus)
+//        
+//        // should be instructions label because VC has no titleLabel
+////        let view = try XCTUnwrap(screen.initialVoiceOverView as? UILabel)
+//        XCTAssertEqual(view.text, "QR Scanning instruction area, we can instruct the user from here")
+//    }
 }
 
 extension ScanningViewController {

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ScanningViewControllerTests.swift
@@ -37,6 +37,8 @@ final class ScanningViewControllerTests: XCTestCase {
     
     override func tearDown() {
         sut = nil
+        captureSession = nil
+        presenter = nil
         super.tearDown()
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -33,8 +33,11 @@ open class BaseViewController: UIViewController {
         }
     }
     
-    public override func viewIsAppearing(_ animated: Bool) {
-        super.viewIsAppearing(animated)
+    // TODO: GOVAPP-228 reimplement `viewIsAppearing` method
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
         
         Task { @MainActor in
             if let screen = self as? VoiceOverFocus {
@@ -42,11 +45,6 @@ open class BaseViewController: UIViewController {
                                      argument: screen.initialVoiceOverView)
             }
         }
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel?.didAppear()
     }
     
     @objc private func dismissScreen() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -31,13 +31,6 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
-    }
-    
-    // TODO: GOVAPP-228 reimplement `viewIsAppearing` method
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel?.didAppear()
         
         Task { @MainActor in
             if let screen = self as? VoiceOverFocus {
@@ -45,6 +38,13 @@ open class BaseViewController: UIViewController {
                                      argument: screen.initialVoiceOverView)
             }
         }
+    }
+    
+    // TODO: GOVAPP-228 reimplement `viewIsAppearing` method
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
     }
     
     @objc private func dismissScreen() {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -14,7 +14,7 @@ import Vision
 ///
 ///  The `instructionsLabel` and `cameraView` are within `view`. The view controller adds the `childView`
 
-public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSession>: BaseViewController, VoiceOverFocus,
+public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSession>: BaseViewController,
                                                                                      AVCaptureVideoDataOutputSampleBufferDelegate {
     private let captureDevice: any CaptureDevice.Type
     let captureSession: CaptureSession


### PR DESCRIPTION
# Temporarily moving VoiceOverFocus functionality

Moving the `VoiceOverFocus` functionality to the `viewWillAppear` lifecycle method temporarily (until all pipelines are on Xcode 15 or later and can use `viewIsAppearing`)

Also removed `VoiceOverFocus` conformance from `ScanningViewController` because there seems to be a lifecycle defect there.


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
