### PR TITLE
fix: move voiceoverfocus method to `viewDidAppear` and fix tests

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/DatePickerScreenViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/DatePickerScreenViewControllerTests.swift
@@ -89,6 +89,7 @@ extension DatePickerScreenViewControllerTests {
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -102,6 +102,7 @@ extension GDSErrorViewControllerTests {
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -47,12 +47,15 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
 extension GDSInstructionsViewControllerTests {
     func testDidAppear() {
         XCTAssertFalse(screenDidAppear)
+        sut.beginAppearanceTransition(true, animated: false)
         sut.viewDidAppear(false)
+        sut.endAppearanceTransition()
         XCTAssertTrue(screenDidAppear)
     }
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -61,6 +61,7 @@ extension InstructionsWithImageViewControllerTests {
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -72,6 +72,7 @@ extension IntroViewControllerTests {
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ListOptionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ListOptionsViewControllerTests.swift
@@ -45,14 +45,15 @@ extension ListOptionsViewControllerTests {
     func testDidAppear() {
         XCTAssertFalse(screenDidAppear)
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
-        sut.viewWillAppear(false)
         XCTAssertTrue(screenDidAppear)
     }
     
     func testWillAppear() {
         XCTAssertNil(sut.navigationItem.rightBarButtonItem)
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         sut.viewDidAppear(false)
         XCTAssertNotNil(sut.navigationItem.rightBarButtonItem)
@@ -60,6 +61,7 @@ extension ListOptionsViewControllerTests {
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -39,12 +39,14 @@ extension ModalInfoViewControllerTests {
         XCTAssertFalse(try sut.bodyLabel.accessibilityTraits.contains(.header))
         XCTAssert(try sut.bodyLabel.textColor == .gdsGrey)
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         XCTAssertEqual(try sut.rightBarButtonItem.title, "Done")
     }
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
@@ -59,12 +59,14 @@ extension ResultsViewControllerTests {
     func testDidAppear() {
         XCTAssertFalse(screenDidAppear)
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         XCTAssertTrue(screenDidAppear)
     }
     
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
+        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         
         let screen = try XCTUnwrap(sut as VoiceOverFocus)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
@@ -52,9 +52,8 @@ final class TextInputViewControllerTests: XCTestCase {
 extension TextInputViewControllerTests {
     func testDidAppear() {
         XCTAssertFalse(screenDidAppear)
-        sut.beginAppearanceTransition(false, animated: false)
+        sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
-        sut.viewDidAppear(false)
         XCTAssertTrue(screenDidAppear)
     }
     
@@ -101,6 +100,7 @@ extension TextInputViewControllerTests {
         XCTAssertEqual(sut.navigationItem.hidesBackButton, true)
         
         sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
         XCTAssertNotNil(sut.navigationItem.rightBarButtonItem)
         XCTAssertEqual(sut.navigationItem.rightBarButtonItem?.title, "Right bar button")
         

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -31,13 +31,6 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
-        
-        Task { @MainActor in
-            if let screen = self as? VoiceOverFocus {
-                UIAccessibility.post(notification: .screenChanged,
-                                     argument: screen.initialVoiceOverView)
-            }
-        }
     }
     
     // TODO: GOVAPP-228 reimplement `viewIsAppearing` method
@@ -45,6 +38,13 @@ open class BaseViewController: UIViewController {
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel?.didAppear()
+        
+        Task { @MainActor in
+            if let screen = self as? VoiceOverFocus {
+                UIAccessibility.post(notification: .screenChanged,
+                                     argument: screen.initialVoiceOverView)
+            }
+        }
     }
     
     @objc private func dismissScreen() {


### PR DESCRIPTION
# GOVAPP-227

Moving the `VoiceOverFocus` method temporarily to `viewDidAppear` (from `viewWillAppear`) to make the functionality more reliable.

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
