### PR TITLE
fix: reimplement `viewIsAppearing` method for voice over focus

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.0.1.app
+          sudo xcode-select -s /Applications/Xcode_15.1.app
           
       - name: Build and Test
         run: |

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -21,7 +21,7 @@ jobs:
           
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.0.1.app
+          sudo xcode-select -s /Applications/Xcode_15.1.app
           
       - name: Build and Test
         run: |

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -18,7 +18,7 @@ open class BaseViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
+    open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         navigationController?.setNavigationBarHidden(false, animated: false)
@@ -31,7 +31,10 @@ open class BaseViewController: UIViewController {
                                                            target: self,
                                                            action: #selector(dismissScreen))
         }
-        
+    }
+    
+    open override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         Task { @MainActor in
             if let screen = self as? VoiceOverFocus {
                 UIAccessibility.post(notification: .screenChanged,
@@ -40,9 +43,7 @@ open class BaseViewController: UIViewController {
         }
     }
     
-    // TODO: GOVAPP-228 reimplement `viewIsAppearing` method
-    
-    public override func viewDidAppear(_ animated: Bool) {
+    open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel?.didAppear()
     }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -15,6 +15,7 @@ import Vision
 ///  The `instructionsLabel` and `cameraView` are within `view`. The view controller adds the `childView`
 
 public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSession>: BaseViewController,
+                                                                                     VoiceOverFocus,
                                                                                      AVCaptureVideoDataOutputSampleBufferDelegate {
     private let captureDevice: any CaptureDevice.Type
     let captureSession: CaptureSession


### PR DESCRIPTION
# GOVAPP-228: Reimplement `viewIsAppearing` method 

This includes: 
* setting Xcode-select to 15.1 which is now available
* setting `BaseViewController` lifecycle methods to `open` access control on so they can be overridden if required


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
