### PR TITLE
fix: allowing us to change the font of title on BulletView

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
+++ b/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2B2F43FB2AE912BA00BDCC72 /* MockIconScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2F43FA2AE912BA00BDCC72 /* MockIconScreenViewModel.swift */; };
 		2B74D6652AC317B2002D992C /* Demo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2B9BDC122ABC5A5600452E23 /* Demo.storyboard */; };
 		2B78F2FA2AD598FC003C3445 /* MockDialogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B78F2F92AD598FC003C3445 /* MockDialogPresenter.swift */; };
+		2B9375192B500DAD00E2A6B9 /* MockBulletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9375182B500DAD00E2A6B9 /* MockBulletViewModel.swift */; };
 		2B9BDC0D2ABC5A5600452E23 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9BDC0C2ABC5A5600452E23 /* AppDelegate.swift */; };
 		2B9BDC0F2ABC5A5600452E23 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9BDC0E2ABC5A5600452E23 /* SceneDelegate.swift */; };
 		2B9BDC112ABC5A5600452E23 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9BDC102ABC5A5600452E23 /* DemoViewController.swift */; };
@@ -84,6 +85,7 @@
 		2B0844102ABC7A7700188BA0 /* XCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
 		2B2F43FA2AE912BA00BDCC72 /* MockIconScreenViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockIconScreenViewModel.swift; sourceTree = "<group>"; };
 		2B78F2F92AD598FC003C3445 /* MockDialogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDialogPresenter.swift; sourceTree = "<group>"; };
+		2B9375182B500DAD00E2A6B9 /* MockBulletViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBulletViewModel.swift; sourceTree = "<group>"; };
 		2B9BDC092ABC5A5600452E23 /* GDSCommon-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GDSCommon-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B9BDC0C2ABC5A5600452E23 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2B9BDC0E2ABC5A5600452E23 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 				2BCBA1252ACDB408009ED436 /* MockQRScanningViewModel.swift */,
 				21D9929E2B13F4DA00F4982F /* MockResultsViewModel.swift */,
 				C8FC500C2B1F770900083CB4 /* MockErrorViewModel.swift */,
+				2B9375182B500DAD00E2A6B9 /* MockBulletViewModel.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				96588BE82AD06CD20035FF93 /* MockTextInputViewModel.swift in Sources */,
 				96588BEA2AD06CE30035FF93 /* MockTextFieldViewModel.swift in Sources */,
 				96588BE62AD06A430035FF93 /* ViewControllerInitialiser+Extensions.swift in Sources */,
+				2B9375192B500DAD00E2A6B9 /* MockBulletViewModel.swift in Sources */,
 				C8C9297F2ACDCA1700A130C3 /* MockIntroViewModel.swift in Sources */,
 				21D9929F2B13F4DA00F4982F /* MockResultsViewModel.swift in Sources */,
 				2BF197222ABDA05500AC9620 /* MockInstructionWithImageViewModel.swift in Sources */,

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockBulletViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockBulletViewModel.swift
@@ -1,0 +1,16 @@
+import GDSCommon
+import UIKit
+
+struct MockBulletViewModel: BulletViewModel {
+    var title: String?
+    var titleFont: UIFont?
+    var text: [String]
+    
+    init(title: String? = "This is the bullet view",
+         titleFont: UIFont? = .init(style: .title2, weight: .bold),
+         text: [String] = ["Here we can list things we want the user to know", "we can use this as a way to step them through an action", "or give details of a process"]) {
+        self.title = title
+        self.titleFont = titleFont
+        self.text = text
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -1,15 +1,25 @@
 import GDSCommon
 import UIKit
 
+struct MockBulletViewModel: BulletViewModel {
+    var title: String?
+    var titleFont: UIFont?
+    var text: [String]
+    
+    init(title: String? = "This is the bullet view", 
+         titleFont: UIFont? = .init(style: .largeTitle, weight: .bold),
+         text: [String] = ["Here we can list things we want the user to know", "we can use this as a way to step them through an action", "or give details of a process"]) {
+        self.title = title
+        self.titleFont = titleFont
+        self.text = text
+    }
+}
+
 struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the Instructions View"
     let body: String = "We can add a subtitle here to give some extra context"
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
-    let childView: UIView = BulletView(title: "This is the bullet view",
-                                       titleFont: .init(style: .title2, weight: .bold),
-                                       text: ["Here we can list things we want the user to know",
-                                              "we can use this as a way to step them through an action",
-                                              "or give details of a process"])
+    let childView: UIView = BulletView(viewModel: MockBulletViewModel())
     let buttonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
     let backButtonIsHidden: Bool = false

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -6,6 +6,7 @@ struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     let body: String = "We can add a subtitle here to give some extra context"
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
     let childView: UIView = BulletView(title: "This is the bullet view",
+                                       titleFont: .init(style: .title2, weight: .bold),
                                        text: ["Here we can list things we want the user to know",
                                               "we can use this as a way to step them through an action",
                                               "or give details of a process"])

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -1,20 +1,6 @@
 import GDSCommon
 import UIKit
 
-struct MockBulletViewModel: BulletViewModel {
-    var title: String?
-    var titleFont: UIFont?
-    var text: [String]
-    
-    init(title: String? = "This is the bullet view", 
-         titleFont: UIFont? = .init(style: .largeTitle, weight: .bold),
-         text: [String] = ["Here we can list things we want the user to know", "we can use this as a way to step them through an action", "or give details of a process"]) {
-        self.title = title
-        self.titleFont = titleFont
-        self.text = text
-    }
-}
-
 struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the Instructions View"
     let body: String = "We can add a subtitle here to give some extra context"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -16,10 +16,10 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
         super.setUp()
         
         bulletView = BulletView(title: "bullet title",
-                                titleFont: .init(style: .largeTitle),
                                 text: ["bullet 1",
                                        "bullet 2",
-                                       "bullet 3"])
+                                       "bullet 3"],
+                                titleFont: .init(style: .largeTitle))
         
         let buttonViewModel = MockButtonViewModel(title: GDSLocalisedString(stringLiteral: "button title")) {
             self.didTapButton = true

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -16,9 +16,10 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
         super.setUp()
         
         bulletView = BulletView(title: "bullet title",
-                                 text: ["bullet 1",
-                                        "bullet 2",
-                                        "bullet 3"])
+                                titleFont: .init(style: .largeTitle),
+                                text: ["bullet 1",
+                                       "bullet 2",
+                                       "bullet 3"])
         
         let buttonViewModel = MockButtonViewModel(title: GDSLocalisedString(stringLiteral: "button title")) {
             self.didTapButton = true
@@ -96,6 +97,7 @@ extension GDSInstructionsViewControllerTests {
         let stack: UIStackView = try XCTUnwrap(bullets[child: "bullet-stack"])
         let bulletLabels: [UILabel] = try XCTUnwrap(stack.arrangedSubviews as? [UILabel])
         
+        XCTAssertEqual(bulletTitle.font, UIFont.init(style: .largeTitle))
         XCTAssertEqual(bulletTitle.text, "bullet title")
         XCTAssertEqual(bulletLabels[0].text, "\t●\tbullet 1")
         XCTAssertEqual(bulletLabels[1].text, "\t●\tbullet 2")

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -121,9 +121,9 @@ loadResourceWithCallback() {
 ```
 
 ### BulletView
-A view that is used for displaying a list with bullet points. We have the ability to pass through a title and array of text to be displayed in the list. This component is shared across multiple journeys within the `GOV.UK ID Check` app. 
+A view that is used for displaying a list with bullet points. There is the ability to pass through a title and array of text to be displayed in the list. This component is shared across multiple journeys within the `GOV.UK ID Check` app. 
 
-An example usage is where we have a list of checks for the user to make before scanning their document. 
+An example usage would be a list of checks for a user to make before completing an action. 
 
 ```swift
 let viewModel = BulletViewModel(title: "Bullet List Title,

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -125,10 +125,24 @@ A view that is used for displaying a list with bullet points. There is the abili
 
 An example usage would be a list of checks for a user to make before completing an action. 
 
+There is the ability to set titleFont like the example below:
 ```swift
 let viewModel = BulletViewModel(title: "Bullet List Title,
-                                titleFont: = UIFont(style: .title2, weight: .bold),
+                                text: ["First Bullet", "Second Bullet", "Third Bullet],
+                                titleFont: = UIFont(style: .title2, weight: .bold))
+func addBulletView() {
+    let bulletView = BulletView(viewModel: bulletViewModel)
+    bulletView.accessibilityIdentifier = "bulletView"
+    stackView.addArrangedSubview(bulletView)
+}
+```
+
+Additionally, there is a default parameter set so titleFont does not need to be passed through.
+
+```swift
+let viewModel = BulletViewModel(title: "Bullet List Title,
                                 text: ["First Bullet", "Second Bullet", "Third Bullet])
+                                
 func addBulletView() {
     let bulletView = BulletView(viewModel: bulletViewModel)
     bulletView.accessibilityIdentifier = "bulletView"

--- a/Sources/GDSCommon/README.md
+++ b/Sources/GDSCommon/README.md
@@ -120,6 +120,22 @@ loadResourceWithCallback() {
 }
 ```
 
+### BulletView
+A view that is used for displaying a list with bullet points. We have the ability to pass through a title and array of text to be displayed in the list. This component is shared across multiple journeys within the `GOV.UK ID Check` app. 
+
+An example usage is where we have a list of checks for the user to make before scanning their document. 
+
+```swift
+let viewModel = BulletViewModel(title: "Bullet List Title,
+                                titleFont: = UIFont(style: .title2, weight: .bold),
+                                text: ["First Bullet", "Second Bullet", "Third Bullet])
+func addBulletView() {
+    let bulletView = BulletView(viewModel: bulletViewModel)
+    bulletView.accessibilityIdentifier = "bulletView"
+    stackView.addArrangedSubview(bulletView)
+}
+```
+
 ## Patterns
 
 ### BaseViewController

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -3,7 +3,7 @@ import UIKit
 /// `BulletView` creates a bulleted list from an array of `String`
 ///  The title is an Optional `String`
 ///  The text is of type `[String]`
-///  The titleFont is an Optional `UIFont`
+///  The titleFont is an Optional `UIFont` - it has a default value of `.title3` and a weight of `.semibold`
 public final class BulletView: NibView {
     private let title: String?
     private let text: [String]
@@ -16,8 +16,8 @@ public final class BulletView: NibView {
     ///   - titleFont: an optional font applied to `title`
     ///   - text: the array of `String` that is constructed into the list
     public init(title: String?,
-                titleFont: UIFont = .init(style: .title3, weight: .semibold),
-                text: [String]) {
+                text: [String],
+                titleFont: UIFont = .init(style: .title3, weight: .semibold)) {
         self.title = title
         self.text = text
         self.titleFont = titleFont
@@ -30,8 +30,8 @@ public final class BulletView: NibView {
     /// - Parameter viewModel: ``BulletViewModel``
     public convenience init(viewModel: BulletViewModel) {
         self.init(title: viewModel.title,
-                  titleFont: viewModel.titleFont ?? .init(style: .title3, weight: .semibold),
-                  text: viewModel.text)
+                  text: viewModel.text,
+                  titleFont: viewModel.titleFont ?? .init(style: .title3, weight: .semibold))
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -12,7 +12,7 @@ public final class BulletView: NibView {
     /// - Parameters:
     ///   - title: an optional bold formated title to `BulletView`
     ///   - text: the array of `String` that is constructed into the list
-    public init(title: String?, 
+    public init(title: String?,
                 titleFont: UIFont = .init(style: .title3, weight: .semibold),
                 text: [String]) {
         self.title = title

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -2,6 +2,8 @@ import UIKit
 
 /// `BulletView` creates a bulleted list from an array of `String`
 ///  The title is an Optional `String`
+///  The text is of type `[String]`
+///  The titleFont is an Optional `UIFont`
 public final class BulletView: NibView {
     private let title: String?
     private let text: [String]
@@ -11,13 +13,14 @@ public final class BulletView: NibView {
     /// constructs a vertical stack as a bulleted list (`bulletStack`)
     /// - Parameters:
     ///   - title: an optional bold formated title to `BulletView`
+    ///   - titleFont: an optional font applied to `title`
     ///   - text: the array of `String` that is constructed into the list
     public init(title: String?,
-                titleFont: UIFont = .init(style: .title3, weight: .semibold),
+                titleFont: UIFont?,
                 text: [String]) {
         self.title = title
         self.text = text
-        self.titleFont = titleFont
+        self.titleFont = titleFont ?? .init(style: .title3, weight: .semibold)
         super.init(bundle: .module)
         self.accessibilityIdentifier = "bullet-view"
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -26,7 +29,7 @@ public final class BulletView: NibView {
     /// Convenience initaliser to initialise a `BulletView` directly from a ``BulletViewModel``
     /// - Parameter viewModel: ``BulletViewModel``
     public convenience init(viewModel: BulletViewModel) {
-        self.init(title: viewModel.title, text: viewModel.text)
+        self.init(title: viewModel.title, titleFont: viewModel.titleFont, text: viewModel.text)
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -3,7 +3,7 @@ import UIKit
 /// `BulletView` creates a bulleted list from an array of `String`
 ///  The title is an Optional `String`
 ///  The text is of type `[String]`
-///  The titleFont is an Optional `UIFont` - it has a default value of `.title3` and a weight of `.semibold`
+///  The titleFont is of type `UIFont` with a default value of `.title3` and a weight of `.semibold`
 public final class BulletView: NibView {
     private let title: String?
     private let text: [String]
@@ -13,7 +13,7 @@ public final class BulletView: NibView {
     /// constructs a vertical stack as a bulleted list (`bulletStack`)
     /// - Parameters:
     ///   - title: an optional bold formated title to `BulletView`
-    ///   - titleFont: an optional font applied to `title`
+    ///   - titleFont: a font applied to `title`
     ///   - text: the array of `String` that is constructed into the list
     public init(title: String?,
                 text: [String],

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -16,11 +16,11 @@ public final class BulletView: NibView {
     ///   - titleFont: an optional font applied to `title`
     ///   - text: the array of `String` that is constructed into the list
     public init(title: String?,
-                titleFont: UIFont?,
+                titleFont: UIFont = .init(style: .title3, weight: .semibold),
                 text: [String]) {
         self.title = title
         self.text = text
-        self.titleFont = titleFont ?? .init(style: .title3, weight: .semibold)
+        self.titleFont = titleFont
         super.init(bundle: .module)
         self.accessibilityIdentifier = "bullet-view"
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -29,7 +29,9 @@ public final class BulletView: NibView {
     /// Convenience initaliser to initialise a `BulletView` directly from a ``BulletViewModel``
     /// - Parameter viewModel: ``BulletViewModel``
     public convenience init(viewModel: BulletViewModel) {
-        self.init(title: viewModel.title, titleFont: viewModel.titleFont, text: viewModel.text)
+        self.init(title: viewModel.title,
+                  titleFont: viewModel.titleFont ?? .init(style: .title3, weight: .semibold),
+                  text: viewModel.text)
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.swift
@@ -5,15 +5,19 @@ import UIKit
 public final class BulletView: NibView {
     private let title: String?
     private let text: [String]
+    private let titleFont: UIFont
     
     /// Initialiser targets the nib file and requires an array of `String`. From this, the view
     /// constructs a vertical stack as a bulleted list (`bulletStack`)
     /// - Parameters:
     ///   - title: an optional bold formated title to `BulletView`
     ///   - text: the array of `String` that is constructed into the list
-    public init(title: String?, text: [String]) {
+    public init(title: String?, 
+                titleFont: UIFont = .init(style: .title3, weight: .semibold),
+                text: [String]) {
         self.title = title
         self.text = text
+        self.titleFont = titleFont
         super.init(bundle: .module)
         self.accessibilityIdentifier = "bullet-view"
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -31,7 +35,7 @@ public final class BulletView: NibView {
     
     @IBOutlet private var titleLabel: UILabel! {
         didSet {
-            titleLabel.font = .init(style: .title3, weight: .semibold)
+            titleLabel.font = titleFont
             titleLabel.text = title
             titleLabel.isHidden = title == nil
             titleLabel.accessibilityIdentifier = "bullet-title"

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletViewModel.swift
@@ -1,6 +1,8 @@
 import Foundation
+import UIKit
 
 public protocol BulletViewModel {
     var title: String? { get }
+    var titleFont: UIFont? { get }
     var text: [String] { get }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -79,6 +79,7 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         makeScannerCaptureView()
         updateRegionOfInterest()
         addImageOverlay()
+        setBackButtonTitle()
         previewLayer.frame = cameraView.layer.bounds
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/Scanner/ScanningViewController.swift
@@ -79,7 +79,6 @@ public final class ScanningViewController<CaptureSession: GDSCommon.CaptureSessi
         makeScannerCaptureView()
         updateRegionOfInterest()
         addImageOverlay()
-        setBackButtonTitle()
         previewLayer.frame = cameraView.layer.bounds
     }
     

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -7,7 +7,9 @@ internal final class BulletViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        sut = .init(title: "exampleTitle", text: ["one", "two", "three"])
+        sut = .init(title: "exampleTitle", 
+                    titleFont: .init(style: .title2, weight: .bold),
+                    text: ["one", "two", "three"])
     }
     
     override func tearDown() {

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -32,6 +32,7 @@ extension BulletViewTests {
     func test_initWithViewModel() {
         struct MockBulletViewModel: BulletViewModel {
             let title: String? = nil
+            let titleFont: UIFont? = .init(style: .title2, weight: .bold)
             let text = ["bullet 1",
                        "bullet 2",
                        "bullet 3",

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -7,7 +7,7 @@ internal final class BulletViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        sut = .init(title: "exampleTitle", 
+        sut = .init(title: "exampleTitle",
                     titleFont: .init(style: .title2, weight: .bold),
                     text: ["one", "two", "three"])
     }

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -8,8 +8,8 @@ internal final class BulletViewTests: XCTestCase {
         super.setUp()
 
         sut = .init(title: "exampleTitle",
-                    titleFont: .init(style: .title2, weight: .bold),
-                    text: ["one", "two", "three"])
+                    text: ["one", "two", "three"],
+                    titleFont: .init(style: .title2, weight: .bold))
     }
     
     override func tearDown() {
@@ -53,7 +53,7 @@ extension BulletViewTests {
     }
     
     func test_initWithDefaultTitleFont() {
-        sut = BulletView(title: "Title", text: ["bullet 1", "bullet 2", "bullet 3", "bullet 4"]
+        sut = BulletView(title: "Title", text: ["bullet 1", "bullet 2", "bullet 3", "bullet 4"])
         try XCTAssertEqual(sut.titleLabel.text, "Title")
         try XCTAssertEqual(sut.titleLabel.font, .init(style: .title3, weight: .semibold))
     }

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -51,6 +51,12 @@ extension BulletViewTests {
         try XCTAssertEqual("\t●\tbullet 3", sut.bulletLabels[2].text)
         try XCTAssertEqual("\t●\tbullet 4", sut.bulletLabels[3].text)
     }
+    
+    func test_initWithDefaultTitleFont() {
+        sut = BulletView(title: "Title", text: ["bullet 1", "bullet 2", "bullet 3", "bullet 4"]
+        try XCTAssertEqual(sut.titleLabel.text, "Title")
+        try XCTAssertEqual(sut.titleLabel.font, .init(style: .title3, weight: .semibold))
+    }
 }
 
 extension BulletView {


### PR DESCRIPTION
# fix: allowing us to change the font of title on BulletView

_Thank you for your contribution to the project._

A change to allow us to pass through an optional titleFont parameter to change how the BulletView title looks. We have set a default font so that this does not affect existing implementations.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
