### PR TITLE
fix: ensuring icon isn't set in storyboard

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
+++ b/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1E891B722B628AA000744E3D /* MockGDSInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E891B712B628AA000744E3D /* MockGDSInformationViewModel.swift */; };
-		1E891B772B63CCB000744E3D /* GDSInformationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E891B762B63CCB000744E3D /* GDSInformationControllerTests.swift */; };
+		1E891B772B63CCB000744E3D /* GDSInformationViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E891B762B63CCB000744E3D /* GDSInformationViewControllerTests.swift */; };
 		21AB39DC2B142B5400A26268 /* ResultsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB39DB2B142B5400A26268 /* ResultsViewControllerTests.swift */; };
 		21D9929F2B13F4DA00F4982F /* MockResultsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D9929E2B13F4DA00F4982F /* MockResultsViewModel.swift */; };
 		2B0844032ABC79BB00188BA0 /* GDSCommon_DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0844022ABC79BB00188BA0 /* GDSCommon_DemoTests.swift */; };
@@ -31,6 +31,7 @@
 		2BA0632D2AC5C98E0064E354 /* GDSCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 2BA0632C2AC5C98E0064E354 /* GDSCommon */; };
 		2BB5C7892AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5C7882AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift */; };
 		2BCBA1262ACDB408009ED436 /* MockQRScanningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCBA1252ACDB408009ED436 /* MockQRScanningViewModel.swift */; };
+		2BD04BF62B729C0200AC5279 /* MockGDSInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD04BF42B729A1C00AC5279 /* MockGDSInformationViewModel.swift */; };
 		2BF197222ABDA05500AC9620 /* MockInstructionWithImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF197212ABDA05500AC9620 /* MockInstructionWithImageViewModel.swift */; };
 		2BF197242ABDA06D00AC9620 /* MockButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF197232ABDA06D00AC9620 /* MockButtonViewModel.swift */; };
 		2BF197262ABDA08700AC9620 /* MockGDSInstructionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF197252ABDA08700AC9620 /* MockGDSInstructionsViewModel.swift */; };
@@ -77,7 +78,7 @@
 
 /* Begin PBXFileReference section */
 		1E891B712B628AA000744E3D /* MockGDSInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSInformationViewModel.swift; sourceTree = "<group>"; };
-		1E891B762B63CCB000744E3D /* GDSInformationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDSInformationControllerTests.swift; sourceTree = "<group>"; };
+		1E891B762B63CCB000744E3D /* GDSInformationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDSInformationViewControllerTests.swift; sourceTree = "<group>"; };
 		21AB39DB2B142B5400A26268 /* ResultsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsViewControllerTests.swift; sourceTree = "<group>"; };
 		21D9929E2B13F4DA00F4982F /* MockResultsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResultsViewModel.swift; sourceTree = "<group>"; };
 		2B0843F42ABC797E00188BA0 /* MockGDSInstructionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSInstructionsViewModel.swift; sourceTree = "<group>"; };
@@ -103,6 +104,7 @@
 		2B9E00EE2B55439500072EA1 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		2BB5C7882AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningViewControllerTests.swift; sourceTree = "<group>"; };
 		2BCBA1252ACDB408009ED436 /* MockQRScanningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQRScanningViewModel.swift; sourceTree = "<group>"; };
+		2BD04BF42B729A1C00AC5279 /* MockGDSInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSInformationViewModel.swift; sourceTree = "<group>"; };
 		2BF197212ABDA05500AC9620 /* MockInstructionWithImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInstructionWithImageViewModel.swift; sourceTree = "<group>"; };
 		2BF197232ABDA06D00AC9620 /* MockButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockButtonViewModel.swift; sourceTree = "<group>"; };
 		2BF197252ABDA08700AC9620 /* MockGDSInstructionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSInstructionsViewModel.swift; sourceTree = "<group>"; };
@@ -172,7 +174,7 @@
 				21AB39DB2B142B5400A26268 /* ResultsViewControllerTests.swift */,
 				96588BEB2AD6AD8A0035FF93 /* TextInputViewControllerTests.swift */,
 				C8A3955E2B20BA6700333669 /* GDSErrorViewControllerTests.swift */,
-				1E891B762B63CCB000744E3D /* GDSInformationControllerTests.swift */,
+				1E891B762B63CCB000744E3D /* GDSInformationViewControllerTests.swift */,
 			);
 			path = "GDSCommon-DemoTests";
 			sourceTree = "<group>";
@@ -256,6 +258,7 @@
 				2B0843F42ABC797E00188BA0 /* MockGDSInstructionsViewModel.swift */,
 				968598AC2B03878900462D0B /* MockBaseViewModel.swift */,
 				7C51376F2AD99EB600163E83 /* Scanning */,
+				2BD04BF42B729A1C00AC5279 /* MockGDSInformationViewModel.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -418,11 +421,12 @@
 				2B0844112ABC7A7700188BA0 /* XCTestCase.swift in Sources */,
 				96588BE02AD046420035FF93 /* DatePickerScreenViewControllerTests.swift in Sources */,
 				2BB5C7892AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift in Sources */,
-				1E891B772B63CCB000744E3D /* GDSInformationControllerTests.swift in Sources */,
+				1E891B772B63CCB000744E3D /* GDSInformationViewControllerTests.swift in Sources */,
 				7C51377B2AD9DA8A00163E83 /* MockCaptureDevice.swift in Sources */,
 				7C5137752AD99EF700163E83 /* MockDetectBarcodeRequest.swift in Sources */,
 				968598AE2B03891000462D0B /* MockBaseViewModel.swift in Sources */,
 				2B08440F2ABC7A5B00188BA0 /* UIView+Test_Extensions.swift in Sources */,
+				2BD04BF62B729C0200AC5279 /* MockGDSInformationViewModel.swift in Sources */,
 				2B0844032ABC79BB00188BA0 /* GDSCommon_DemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
@@ -4,19 +4,27 @@ import XCTest
 final class GDSInformationViewControllerTests: XCTestCase {
     var viewModel: GDSInformationViewModel!
     var sut: GDSInformationViewController!
-    var primaryButton = false
-    var secondaryButton = false
+    
+    var primaryButtonViewModel: MockButtonViewModel!
+    var secondaryButtonViewModel: MockButtonViewModel!
+    
+    var didTap_primaryButton = false
+    var didTap_secondaryButton = false
     var viewDidAppear = false
     var viewDidDismiss = false
     
     override func setUp() {
         super.setUp()
         
-        viewModel = TestViewModel {
-            self.primaryButton = true
-        } secondaryButtonAction: {
-            self.secondaryButton = true
-        } appearAction: {
+        primaryButtonViewModel = MockButtonViewModel(title: "Information primary button title") {
+            self.didTap_primaryButton = true
+        }
+        secondaryButtonViewModel = MockButtonViewModel(title: "Information secondary button title") {
+            self.didTap_secondaryButton = true
+        }
+        
+        viewModel = MockGDSInformationViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                secondaryButtonViewModel: secondaryButtonViewModel) {
             self.viewDidAppear = true
         } dismissAction: {
             self.viewDidDismiss = true
@@ -29,45 +37,6 @@ final class GDSInformationViewControllerTests: XCTestCase {
         sut = nil
         
         super.tearDown()
-    }
-}
-
-private struct TestViewModel: GDSInformationViewModel, BaseViewModel {
-    let image: String = "lock"
-    let imageWeight: UIFont.Weight? = .semibold
-    let imageColour: UIColor? = .gdsPrimary
-    let imageHeightConstraint: CGFloat? = 55
-    let title: GDSLocalisedString = "Information screen title"
-    let body: GDSLocalisedString? = "Information screen body"
-    let footnote: GDSLocalisedString? = "Information screen footnote"
-    let primaryButtonViewModel: ButtonViewModel
-    let secondaryButtonViewModel: ButtonViewModel?
-    
-    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
-    let backButtonIsHidden: Bool = false
-    let appearAction: () -> Void
-    let dismissAction: () -> Void
-    
-    init(primaryButtonAction: @escaping () -> Void,
-         secondaryButtonAction: @escaping () -> Void,
-         appearAction: @escaping () -> Void,
-         dismissAction: @escaping () -> Void) {
-        primaryButtonViewModel = MockButtonViewModel(title: "Information primary button title") {
-            primaryButtonAction()
-        }
-        secondaryButtonViewModel = MockButtonViewModel(title: "Information secondary button title") {
-            secondaryButtonAction()
-        }
-        self.appearAction = appearAction
-        self.dismissAction = dismissAction
-    }
-    
-    func didAppear() {
-        appearAction()
-    }
-    
-    func didDismiss() {
-        dismissAction()
     }
 }
 
@@ -84,20 +53,54 @@ extension GDSInformationViewControllerTests {
         XCTAssertEqual(try sut.informationFootnoteLabel.font, .footnote)
         XCTAssertEqual(try sut.informationFootnoteLabel.maximumContentSizeCategory, .accessibilityMedium)
         XCTAssertFalse(try sut.informationFootnoteLabel.accessibilityTraits.contains(.header))
-        XCTAssertEqual(try sut.informationPrimaryButton.title(for: .normal), "Information primary button title")
-        XCTAssertEqual(try sut.informationSecondaryButton.title(for: .normal), "Information secondary button title")
+        XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Information primary button title")
+        XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Information secondary button title")
+    }
+    
+    func test_primaryButtonNoIcon() throws {
+        XCTAssertNil(viewModel.primaryButtonViewModel.icon)
+        XCTAssertNil(try sut.primaryButton.icon)
+    }
+    
+    func test_primaryButtonWithIcon() throws {
+        primaryButtonViewModel = MockButtonViewModel(title: "Information primary button title",
+                                                       icon: MockButtonIconViewModel()) {}
+        
+        viewModel = MockGDSInformationViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                secondaryButtonViewModel: secondaryButtonViewModel) { } dismissAction: { }
+        sut = GDSInformationViewController(viewModel: viewModel)
+        
+        XCTAssertNotNil(viewModel.primaryButtonViewModel.icon)
+        XCTAssertNotNil(try sut.primaryButton.icon)
+    }
+    
+    func test_secondaryButtonNoIcon() throws {
+        XCTAssertNil(viewModel.secondaryButtonViewModel?.icon)
+        XCTAssertNil(try sut.secondaryButton.icon)
+    }
+    
+    func test_secondaryButtonWithIcon() throws {
+        secondaryButtonViewModel = MockButtonViewModel(title: "Information secondary button title",
+                                                       icon: MockButtonIconViewModel()) {}
+        
+        viewModel = MockGDSInformationViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                secondaryButtonViewModel: secondaryButtonViewModel) { } dismissAction: { }
+        sut = GDSInformationViewController(viewModel: viewModel)
+        
+        XCTAssertNotNil(viewModel.secondaryButtonViewModel?.icon)
+        XCTAssertNotNil(try sut.secondaryButton.icon)
     }
     
     func test_primaryButtonAction() throws {
-        XCTAssertFalse(primaryButton)
-        try sut.informationPrimaryButton.sendActions(for: .touchUpInside)
-        XCTAssertTrue(primaryButton)
+        XCTAssertFalse(didTap_primaryButton)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didTap_primaryButton)
     }
     
     func test_secondaryButtonAction() throws {
-        XCTAssertFalse(secondaryButton)
-        try sut.informationSecondaryButton.sendActions(for: .touchUpInside)
-        XCTAssertTrue(secondaryButton)
+        XCTAssertFalse(didTap_secondaryButton)
+        try sut.secondaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didTap_secondaryButton)
     }
     
     func test_didAppear() throws {
@@ -107,7 +110,7 @@ extension GDSInformationViewControllerTests {
         XCTAssertTrue(viewDidAppear)
     }
     
-    func testVoiceOverFocusElement() throws {
+    func test_voiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
         
@@ -126,6 +129,11 @@ extension GDSInformationViewControllerTests {
         _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
         XCTAssertTrue(viewDidDismiss)
     }
+}
+
+struct MockButtonIconViewModel: ButtonIconViewModel {
+    var iconName: String = "arrow.up.right"
+    var symbolPosition: SymbolPosition = .afterTitle
 }
 
 extension GDSInformationViewController {
@@ -153,13 +161,13 @@ extension GDSInformationViewController {
         }
     }
     
-    var informationPrimaryButton: UIButton {
+    var primaryButton: RoundedButton {
         get throws {
             try XCTUnwrap(view[child: "information-primary-button"])
         }
     }
     
-    var informationSecondaryButton: UIButton {
+    var secondaryButton: SecondaryButton {
         get throws {
             try XCTUnwrap(view[child: "information-secondary-button"])
         }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
@@ -61,19 +61,7 @@ extension GDSInformationViewControllerTests {
         XCTAssertNil(viewModel.primaryButtonViewModel.icon)
         XCTAssertNil(try sut.primaryButton.icon)
     }
-    
-    func test_primaryButtonWithIcon() throws {
-        primaryButtonViewModel = MockButtonViewModel(title: "Information primary button title",
-                                                       icon: MockButtonIconViewModel()) {}
-        
-        viewModel = MockGDSInformationViewModel(primaryButtonViewModel: primaryButtonViewModel,
-                                                secondaryButtonViewModel: secondaryButtonViewModel) { } dismissAction: { }
-        sut = GDSInformationViewController(viewModel: viewModel)
-        
-        XCTAssertNotNil(viewModel.primaryButtonViewModel.icon)
-        XCTAssertNotNil(try sut.primaryButton.icon)
-    }
-    
+
     func test_secondaryButtonNoIcon() throws {
         XCTAssertNil(viewModel.secondaryButtonViewModel?.icon)
         XCTAssertNil(try sut.secondaryButton.icon)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInformationViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInformationViewModel.swift
@@ -1,0 +1,37 @@
+import GDSCommon
+import UIKit
+
+struct MockGDSInformationViewModel: GDSInformationViewModel, BaseViewModel {
+    let image: String = "lock"
+    let imageWeight: UIFont.Weight? = .semibold
+    let imageColour: UIColor? = .gdsPrimary
+    let imageHeightConstraint: CGFloat? = 55
+    let title: GDSLocalisedString = "Information screen title"
+    let body: GDSLocalisedString? = "Information screen body"
+    let footnote: GDSLocalisedString? = "Information screen footnote"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let backButtonIsHidden: Bool = false
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    init(primaryButtonViewModel: ButtonViewModel,
+         secondaryButtonViewModel: ButtonViewModel,
+         appearAction: @escaping () -> Void,
+         dismissAction: @escaping () -> Void) {
+        self.primaryButtonViewModel = primaryButtonViewModel
+        self.secondaryButtonViewModel = secondaryButtonViewModel
+        self.appearAction = appearAction
+        self.dismissAction = dismissAction
+    }
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInformation/GDSInformation.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInformation/GDSInformation.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -107,9 +107,6 @@
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" title="Confirm your identity another way"/>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="icon" value="arrow.up.right"/>
-                            </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="secondaryButtonAction:" destination="-1" eventType="touchUpInside" id="yuW-Rb-tBy"/>
                             </connections>


### PR DESCRIPTION
# fix: ensuring icon isn't set in storyboard

We found an issue so that even if we set the icon in the view model of GDSInformationViewController, the icon displayed anyway. Identified that it was due to the icon name being set in the storyboard.

Have renamed various things to keep the code style consistent, and added missing tests which check that the icon is displayed/hidden as required.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
