### PR TITLE
fix: update base view controller init

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 open class BaseViewController: UIViewController {
     private let viewModel: BaseViewModel?
     
-    public init(viewModel: BaseViewModel?, nibName: String, bundle: Bundle) {
+    public init(viewModel: BaseViewModel?, nibName: String?, bundle: Bundle?) {
         self.viewModel = viewModel
         super.init(nibName: nibName, bundle: bundle)
     }


### PR DESCRIPTION
# GOVAPP-294: Make `nib` and `bundle` optional in `BaseViewController` init

Changing these parameters to being optional matches the super init and will allow the `BaseViewController` to be used for view controllers build programmatically (ie, without a `xib` / `nib`)

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
