### PR TITLE
feat: dcmaw-8571 analytics privacy link

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,25 +30,26 @@ jobs:
           brew install swiftlint
           swiftlint --strict
 
-      - name: Xcode select
-        run: |
-          sudo xcode-select -s /Applications/Xcode_15.1.app
-
       - name: Validate Pull Request Name
         id: versioning
-        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 #  pin@v1.0.0
+        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # pin@v1.0.0
         with:
           ACTION_TYPE: 'Validate'
+
+      - name: Xcode select
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Build and Test
         run: |
           xcodebuild -workspace "GDSCommon-Demo.xcworkspace" -scheme GDSCommon-Demo test \
-           -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-           -enableCodeCoverage YES -resultBundlePath result.xcresult
+           -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" \
+           -enableCodeCoverage YES \
+           -resultBundlePath result.xcresult
 
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
           brew install sonar-scanner
 
@@ -56,7 +57,7 @@ jobs:
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml" \
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
             -Dsonar.pullrequest.branch=${{github.head_ref}} \
             -Dsonar.pullrequest.base=${{github.base_ref}}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -23,23 +23,24 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.1.app
+          sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Build and Test
         run: |
           xcodebuild -workspace "GDSCommon-Demo.xcworkspace" -scheme GDSCommon-Demo test \
-           -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-           -enableCodeCoverage YES -resultBundlePath result.xcresult
-            
+           -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" \
+           -enableCodeCoverage YES \
+           -resultBundlePath result.xcresult
+
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
           brew install sonar-scanner
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml"
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -36,4 +36,13 @@ extension MockButtonViewModel {
                             shouldLoadOnTap: false,
                             action: {})
     }
+    
+    static var text: MockButtonViewModel {
+        MockButtonViewModel(title: "Secondary Button",
+                            icon: MockButtonIconViewModel(iconName: "qrcode",
+                                                          symbolPosition: .beforeTitle),
+                            shouldLoadOnTap: false,
+                            action: {})
+    }
+
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -6,7 +6,6 @@ struct MockModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the Modal view"
     let body: GDSLocalisedString = "We can use this if we want the user to complete an action"
     let bodyTextColor: UIColor = .label
-    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
     let backButtonIsHidden: Bool = true
     
@@ -23,7 +22,6 @@ struct MockModalInfoButtonsViewModel: ModalInfoViewModel,
     let title: GDSLocalisedString = "This is the Modal Buttons view"
     let body: GDSLocalisedString = "We can use this if we want the user to complete an action with buttons"
     let bodyTextColor: UIColor = .label
-    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
@@ -39,7 +37,6 @@ struct MockAttributedModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     let body: GDSLocalisedString = .init(stringLiteral: "We can use this attribubted text if we want the user to complete an action",
                                          attributes: [("We can use this attribubted text", [.font: UIFont.bodyBold])])
     let bodyTextColor: UIColor = .label
-    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
     let backButtonIsHidden: Bool = false
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -6,6 +6,7 @@ struct MockModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the Modal view"
     let body: GDSLocalisedString = "We can use this if we want the user to complete an action"
     let bodyTextColor: UIColor = .label
+    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
     let backButtonIsHidden: Bool = true
     
@@ -22,6 +23,7 @@ struct MockModalInfoButtonsViewModel: ModalInfoViewModel,
     let title: GDSLocalisedString = "This is the Modal Buttons view"
     let body: GDSLocalisedString = "We can use this if we want the user to complete an action with buttons"
     let bodyTextColor: UIColor = .label
+    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
@@ -37,6 +39,7 @@ struct MockAttributedModalInfoViewModel: ModalInfoViewModel, BaseViewModel {
     let body: GDSLocalisedString = .init(stringLiteral: "We can use this attribubted text if we want the user to complete an action",
                                          attributes: [("We can use this attribubted text", [.font: UIFont.bodyBold])])
     let bodyTextColor: UIColor = .label
+    let privacyPolicyButtonTitle: GDSLocalisedString? = "Privacy policy"
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
     let backButtonIsHidden: Bool = false
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockModalInfoViewModel.swift
@@ -17,13 +17,16 @@ struct MockModalInfoButtonsViewModel: ModalInfoViewModel,
                                       ModalInfoExtraViewModel,
                                       PageWithPrimaryButtonViewModel,
                                       PageWithSecondaryButtonViewModel,
+                                      PageWithTextButtonViewModel,
                                       BaseViewModel {
+    
     
     let title: GDSLocalisedString = "This is the Modal Buttons view"
     let body: GDSLocalisedString = "We can use this if we want the user to complete an action with buttons"
     let bodyTextColor: UIColor = .label
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel
+    let textButtonViewModel: ButtonViewModel
     let rightBarButtonTitle: GDSLocalisedString? = "Close"
     let backButtonIsHidden: Bool = false
     let preventModalDismiss: Bool = true

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -70,7 +70,8 @@ enum Screens: String, CaseIterable {
             return view
         case .gdsModalButtonsInfoView:
             let view = ModalInfoViewController(viewModel: MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel.primary,
-                                                                                        secondaryButtonViewModel: MockButtonViewModel.secondary))
+                                                                                        secondaryButtonViewModel: MockButtonViewModel.secondary,
+                                                                                        textButtonViewModel: MockButtonViewModel.secondary))
             return view
         case .gdsAttributedModalInfoView:
             let view = ModalInfoViewController(viewModel: MockAttributedModalInfoViewModel())

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -38,7 +38,7 @@ extension ModalInfoViewControllerTests {
                                                   secondaryButtonViewModel: MockButtonViewModel(title: "Secondary button",
                                                                                                 icon: MockButtonIconViewModel(),
                                                                                                 action: { self.secondaryButton = true }),
-                                                  textButtonViewModel: MockButtonViewModel(title: "Text button", 
+                                                  textButtonViewModel: MockButtonViewModel(title: "Text button",
                                                                                            action: {self.textButton = true }))
         
         sut = ModalInfoViewController(viewModel: viewModel)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -6,13 +6,14 @@ final class ModalInfoViewControllerTests: XCTestCase {
     var sut: ModalInfoViewController!
     var primaryButton = false
     var secondaryButton = false
+    var textButton = false
     
     override func tearDown() {
         viewModel = nil
         sut = nil
         primaryButton = false
         secondaryButton = false
-        
+        textButton = false
         super.tearDown()
     }
 }
@@ -36,7 +37,10 @@ extension ModalInfoViewControllerTests {
                                                                                               action: { self.primaryButton = true }),
                                                   secondaryButtonViewModel: MockButtonViewModel(title: "Secondary button",
                                                                                                 icon: MockButtonIconViewModel(),
-                                                                                                action: { self.secondaryButton = true }))
+                                                                                                action: { self.secondaryButton = true }),
+                                                  textButtonViewModel: MockButtonViewModel(title: "Text button", 
+                                                                                           action: {self.textButton = true }))
+        
         sut = ModalInfoViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button")
@@ -50,6 +54,10 @@ extension ModalInfoViewControllerTests {
         XCTAssertFalse(secondaryButton)
         try sut.secondaryButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(secondaryButton)
+        
+        XCTAssertFalse(textButton)
+        try sut.textButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(textButton)
     }
     
     func test_attributedModalInfoView() throws {
@@ -82,6 +90,12 @@ extension ModalInfoViewController {
     var secondaryButton: UIButton {
         get throws {
             try XCTUnwrap(view[child: "modal-info-secondary-button"])
+        }
+    }
+    
+    var textButton: UIButton {
+        get throws {
+            try XCTUnwrap(view[child: "modal-info-text-button"])
         }
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/PageButtonViewModels.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/PageButtonViewModels.swift
@@ -9,3 +9,9 @@ public protocol PageWithPrimaryButtonViewModel {
 public protocol PageWithSecondaryButtonViewModel {
     var secondaryButtonViewModel: ButtonViewModel { get }
 }
+
+/// View model for the views with a button that displays as text i.e privacy policy
+///  - `textButtonViewModel` type is ``ButtonViewModel``
+public protocol PageWithTextButtonViewModel {
+    var textButtonViewModel: ButtonViewModel { get }
+}

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
@@ -28,10 +28,10 @@
                     <rect key="frame" x="0.0" y="48" width="414" height="657"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ZFw-FR-LhT">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="369"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="367.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JqX-kN-ovq">
-                                    <rect key="frame" x="0.0" y="8" width="414" height="353"/>
+                                    <rect key="frame" x="0.0" y="8" width="414" height="351.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Help improve the app by sharing analytics" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="scT-2x-13n">
                                             <rect key="frame" x="16" y="8" width="382" height="82"/>
@@ -54,12 +54,13 @@ You can change your preferences at any time in your Settings. </string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="izO-Kl-cNh">
-                                            <rect key="frame" x="16" y="310.5" width="382" height="34.5"/>
+                                            <rect key="frame" x="16" y="310.5" width="382" height="33"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-Xa-bV6" customClass="SecondaryButton" customModule="GDSCommon">
-                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="34.5"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-Xa-bV6" customClass="SecondaryButton" customModule="GDSCommon">
+                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="33"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     <state key="normal" title="Button"/>
-                                                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                     <connections>
                                                         <action selector="privacyPolicyButtonAction:" destination="-1" eventType="touchUpInside" id="Y3i-CT-1PA"/>
                                                     </connections>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,8 +12,8 @@
             <connections>
                 <outlet property="bodyLabel" destination="JIR-NX-GIB" id="kAJ-hF-WSA"/>
                 <outlet property="primaryButton" destination="VVY-cu-Sbp" id="3Hc-Cr-CKZ"/>
-                <outlet property="privacyPolicyButton" destination="pbD-Xa-bV6" id="8dD-x8-7pZ"/>
                 <outlet property="secondaryButton" destination="ELh-0G-cep" id="r6g-Td-U0N"/>
+                <outlet property="textButton" destination="pbD-Xa-bV6" id="8dD-x8-7pZ"/>
                 <outlet property="titleLabel" destination="scT-2x-13n" id="DcJ-LA-CK1"/>
                 <outlet property="view" destination="PKq-uW-jV8" id="kWd-s6-EJu"/>
             </connections>
@@ -62,7 +61,7 @@ You can change your preferences at any time in your Settings. </string>
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     <state key="normal" title="Button"/>
                                                     <connections>
-                                                        <action selector="privacyPolicyButtonAction:" destination="-1" eventType="touchUpInside" id="Y3i-CT-1PA"/>
+                                                        <action selector="textButtonAction:" destination="-1" eventType="touchUpInside" id="Y3i-CT-1PA"/>
                                                     </connections>
                                                 </button>
                                             </subviews>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoView.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="bodyLabel" destination="JIR-NX-GIB" id="kAJ-hF-WSA"/>
                 <outlet property="primaryButton" destination="VVY-cu-Sbp" id="3Hc-Cr-CKZ"/>
+                <outlet property="privacyPolicyButton" destination="pbD-Xa-bV6" id="8dD-x8-7pZ"/>
                 <outlet property="secondaryButton" destination="ELh-0G-cep" id="r6g-Td-U0N"/>
                 <outlet property="titleLabel" destination="scT-2x-13n" id="DcJ-LA-CK1"/>
                 <outlet property="view" destination="PKq-uW-jV8" id="kWd-s6-EJu"/>
@@ -27,10 +28,10 @@
                     <rect key="frame" x="0.0" y="48" width="414" height="657"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ZFw-FR-LhT">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="322.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="369"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JqX-kN-ovq">
-                                    <rect key="frame" x="0.0" y="8" width="414" height="306.5"/>
+                                    <rect key="frame" x="0.0" y="8" width="414" height="353"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Help improve the app by sharing analytics" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="scT-2x-13n">
                                             <rect key="frame" x="16" y="8" width="382" height="82"/>
@@ -52,6 +53,19 @@ You can change your preferences at any time in your Settings. </string>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="izO-Kl-cNh">
+                                            <rect key="frame" x="16" y="310.5" width="382" height="34.5"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-Xa-bV6" customClass="SecondaryButton" customModule="GDSCommon">
+                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="34.5"/>
+                                                    <state key="normal" title="Button"/>
+                                                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                    <connections>
+                                                        <action selector="privacyPolicyButtonAction:" destination="-1" eventType="touchUpInside" id="Y3i-CT-1PA"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                        </stackView>
                                     </subviews>
                                     <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
                                 </stackView>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -6,10 +6,11 @@ import UIKit
 ///   - `bodyLabel` (type: `UILabel`)
 ///   - `primaryButton` (type: `RoundedButton`)
 ///   - `secondaryButton` (type: `SecondaryButton`)
+///   - `textButton` (type: `SecondaryButton`)
 ///   This screen provides guidance in a modal presentation context
 ///   with a title and body to present the information.
 ///   Additional configuration and buttons can be added to this view by conforming to the:
-///   `BaseViewModel`, `ModalInfoExtraViewModel`, `PageWithPrimaryButtonViewModel` and `PageWithSecondaryButtonViewModel` protocols.
+///   `BaseViewModel`, `ModalInfoExtraViewModel`, `PageWithPrimaryButtonViewModel`, `PageWithSecondaryButtonViewModel` and `PageWithTextButtonViewModel`protocols.
 public final class ModalInfoViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "ModalInfoView" }
     
@@ -84,20 +85,20 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
         (viewModel as? PageWithSecondaryButtonViewModel)?.secondaryButtonViewModel.action()
     }
 
-    @IBOutlet weak var privacyPolicyButton: SecondaryButton! {
+    @IBOutlet private var textButton: SecondaryButton! {
         didSet {
             if let vm = viewModel as? PageWithTextButtonViewModel {
-                privacyPolicyButton.setTitle(vm.textButtonViewModel.title, for: .normal)
-                privacyPolicyButton.accessibilityIdentifier = "privacyButton"
+                textButton.setTitle(vm.textButtonViewModel.title, for: .normal)
+                textButton.accessibilityIdentifier = "modal-info-text-button"
             }
             else {
-                privacyPolicyButton.isHidden = true
+                textButton.isHidden = true
             }
 
         }
     }
 
-    @IBAction func privacyPolicyButtonAction(_ sender: Any) {
+    @IBAction func textButtonAction(_ sender: Any) {
         (viewModel as? PageWithTextButtonViewModel)?.textButtonViewModel.action()
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -83,4 +83,16 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
     @IBAction private func secondaryButtonAction(_ sender: Any) {
         (viewModel as? PageWithSecondaryButtonViewModel)?.secondaryButtonViewModel.action()
     }
+
+    @IBOutlet weak var privacyPolicyButton: SecondaryButton! {
+        didSet {
+            privacyPolicyButton.setTitle(viewModel.privacyPolicyButtonTitle ?? "Privacy policy", for: .normal)
+            privacyPolicyButton.accessibilityIdentifier = "privacyButton"
+        }
+    }
+
+    @IBAction func privacyPolicyButtonAction(_ sender: Any) {
+        (viewModel as? PageWithSecondaryButtonViewModel)?.secondaryButtonViewModel.action()
+    }
+    
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -86,13 +86,19 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
 
     @IBOutlet weak var privacyPolicyButton: SecondaryButton! {
         didSet {
-            privacyPolicyButton.setTitle(viewModel.privacyPolicyButtonTitle ?? "Privacy policy", for: .normal)
-            privacyPolicyButton.accessibilityIdentifier = "privacyButton"
+            if let vm = viewModel as? PageWithTextButtonViewModel {
+                privacyPolicyButton.setTitle(vm.textButtonViewModel.title, for: .normal)
+                privacyPolicyButton.accessibilityIdentifier = "privacyButton"
+            }
+            else {
+                privacyPolicyButton.isHidden = true
+            }
+
         }
     }
 
     @IBAction func privacyPolicyButtonAction(_ sender: Any) {
-        (viewModel as? PageWithSecondaryButtonViewModel)?.secondaryButtonViewModel.action()
+        (viewModel as? PageWithTextButtonViewModel)?.textButtonViewModel.action()
     }
     
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -90,16 +90,13 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
             if let vm = viewModel as? PageWithTextButtonViewModel {
                 textButton.setTitle(vm.textButtonViewModel.title, for: .normal)
                 textButton.accessibilityIdentifier = "modal-info-text-button"
-            }
-            else {
+            } else {
                 textButton.isHidden = true
             }
-
         }
     }
 
-    @IBAction func textButtonAction(_ sender: Any) {
+    @IBAction private func textButtonAction(_ sender: Any) {
         (viewModel as? PageWithTextButtonViewModel)?.textButtonViewModel.action()
     }
-    
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -8,6 +8,7 @@ public protocol ModalInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var bodyTextColor: UIColor { get }
+    var privacyPolicyButtonTitle: GDSLocalisedString? { get }
 }
 
 /// View model for extra configuration on the `ModalInfoViewController`

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -8,7 +8,6 @@ public protocol ModalInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var bodyTextColor: UIColor { get }
-    var privacyPolicyButtonTitle: GDSLocalisedString? { get }
 }
 
 /// View model for extra configuration on the `ModalInfoViewController`

--- a/Tests/GDSCommonTests/ComponentTests/DialogViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/DialogViewTests.swift
@@ -77,18 +77,6 @@ final class DialogViewTests: XCTestCase {
         XCTAssertNil(sut.superview)
     }
     
-    func test_dialogView_asdsfafgsyncPresentation() {
-        let exp = expectation(description: "Removed from superview")
-        
-        Task {
-            await sut.remove(view: viewController.view)
-            exp.fulfill()
-        }
-
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertNil(sut.superview)
-    }
-    
     func test_dialogView_asyncUpdateState() {
         let exp = expectation(description: "Wait for update")
 


### PR DESCRIPTION
# DCMAW-8571: iOS | Add privacy policy link to analytics opt-in page

Add a text button to ModalInfoView, appearing below body text.   This will be used by the OneLogin app to link to the privacy policy

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
