### PR TITLE
fix: dcmaw-8695: Add gdsRed colour to assets

### DIFF
--- a/Sources/GDSCommon/Extensions/UIKit/UIColor+Extensions.swift
+++ b/Sources/GDSCommon/Extensions/UIKit/UIColor+Extensions.swift
@@ -36,6 +36,7 @@ extension UIColor {
     public static let gdsMidGrey = UIColor(.gdsMidGrey)
     public static let gdsOrange = UIColor(.gdsOrange)
     public static let gdsPink = UIColor(.gdsPink)
+    public static let gdsRed = UIColor(.gdsRed)
     public static let gdsPurple = UIColor(.gdsPurple)
     public static let gdsTurquoise = UIColor(.gdsTurquoise)
     // TODO: DCMAW-6572 Review colours based on investigation from Design
@@ -67,6 +68,7 @@ extension UIColor {
         case gdsOrange = "Orange"
         case gdsPink = "Pink"
         case gdsPurple = "Purple"
+        case gdsRed = "Red"
         case gdsTurquoise = "Turquoise"
         // TODO: DCMAW-6572 Review colours based on investigation from Design
         case dialogBackground = "DialogBackground"

--- a/Sources/GDSCommon/Resources/Colours.xcassets/Colours/Red.colorset/Contents.json
+++ b/Sources/GDSCommon/Resources/Colours.xcassets/Colours/Red.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1C",
+          "green" : "0x35",
+          "red" : "0xD4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0x66",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
# DCMAW-8695: Add gdsRed colour to assets

Add "Red" colour as defined by designs.  Seems to have been missed out in original setup.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_


## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
