### PR TITLE
fix: added accessibility identifier to right bar button

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/BaseViewControllerTests.swift
@@ -33,7 +33,6 @@ final class BaseViewControllerTests: XCTestCase {
 extension BaseViewControllerTests {
     func test_labelContents() throws {
         sut.beginAppearanceTransition(true, animated: false)
-        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         let rightBarButton: UIBarButtonItem = try XCTUnwrap(sut.navigationItem.rightBarButtonItem)
         XCTAssertEqual(rightBarButton.title, "right bar button")
@@ -42,7 +41,6 @@ extension BaseViewControllerTests {
     func test_didAppear() {
         XCTAssertFalse(didAppear)
         sut.beginAppearanceTransition(true, animated: false)
-        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         XCTAssertTrue(didAppear)
     }
@@ -50,12 +48,18 @@ extension BaseViewControllerTests {
     func test_didDismiss() {
         XCTAssertFalse(didAppear)
         sut.beginAppearanceTransition(true, animated: false)
-        sut.viewDidAppear(false)
         sut.endAppearanceTransition()
         XCTAssertTrue(didAppear)
         
         XCTAssertFalse(didDismiss)
         _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
         XCTAssertTrue(didDismiss)
+    }
+    
+    func test_rightBarButtonSetsAccessbilityIDOnViewLoad() {
+        XCTAssertNil(sut.navigationItem.rightBarButtonItem?.accessibilityIdentifier)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+        XCTAssertEqual(sut.navigationItem.rightBarButtonItem?.accessibilityIdentifier, "right-bar-button")
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/BaseViewController.swift
@@ -30,6 +30,7 @@ open class BaseViewController: UIViewController {
                                                            style: .done,
                                                            target: self,
                                                            action: #selector(dismissScreen))
+            self.navigationItem.rightBarButtonItem?.accessibilityIdentifier = "right-bar-button"
         }
     }
     


### PR DESCRIPTION
# Add accessibility identifier to right bar button in base view controller

Adding this identifier which will enable consumers to access the right bar button element in `BaseViewController` when writing UI tests

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] ~Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [ ] ~Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] ~Ran the app and tested the feature on a range of device sizes~
      ~Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

- [ ] ~Met all accessibility requirements?~
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
