### PR TITLE
fix: refactored when results action is called

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -17,7 +17,7 @@ class MockListViewModel: GDSListOptionsViewModel, BaseViewModel {
     let screenView: () -> Void
     let dismissAction: () -> Void
     
-    lazy var resultAction:(GDSLocalisedString) -> Void = {{ index in
+    lazy var resultAction: (GDSLocalisedString) -> Void = {{ index in
         self.selectedIndex = index
     }}()
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockListViewModel.swift
@@ -1,8 +1,7 @@
 import GDSCommon
 import UIKit
 
-struct MockListViewModel: GDSListOptionsViewModel, BaseViewModel {
-    
+class MockListViewModel: GDSListOptionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "This is the List Options screen pattern"
     let body: GDSLocalisedString? = "This is the optional body label. If the view model property is `nil` then the label is hidden."
     let childView: UIView?
@@ -10,13 +9,17 @@ struct MockListViewModel: GDSListOptionsViewModel, BaseViewModel {
     let listRows: [GDSLocalisedString] = ["Table view list item 1", "Table view list item two", "Table view list item 3", "Table view list item IV"]
     let listFooter: GDSLocalisedString? = "Optional footer. Configure it on the view model in a similar way as the `body` property. The right bar button works the same way."
     let buttonViewModel: ButtonViewModel
-    let resultAction: (GDSLocalisedString) -> Void
     let secondaryButtonViewModel: ButtonViewModel?
     let rightBarButtonTitle: GDSLocalisedString? = "Right bar button"
     let backButtonIsHidden: Bool = false
+    var selectedIndex: GDSLocalisedString = ""
     
     let screenView: () -> Void
     let dismissAction: () -> Void
+    
+    lazy var resultAction:(GDSLocalisedString) -> Void = {{ index in
+        self.selectedIndex = index
+    }}()
     
     func didDismiss() {
         dismissAction()
@@ -29,13 +32,9 @@ struct MockListViewModel: GDSListOptionsViewModel, BaseViewModel {
     init(childView: UIView? = nil,
          secondaryButtonViewModel: ButtonViewModel? = nil,
          listTitle: GDSLocalisedString? = "Optional table title",
-         resultAction: ((GDSLocalisedString) -> Void)? = nil,
          screenView: (() -> Void)? = nil,
          dismissAction: (() -> Void)? = nil,
          buttonAction: (() -> Void)? = nil) {
-        self.resultAction = resultAction ?? { _ in
-            // the resultAction shouldn't be nil
-        }
         self.screenView = screenView ?? {}
         self.dismissAction = dismissAction ?? {}
         

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSListOptions/GDSListOptionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSListOptions/GDSListOptionsViewController.swift
@@ -111,10 +111,6 @@ public final class GDSListOptionsViewController: BaseViewController, TitledViewC
     }
     
     @IBAction private func primaryButton(_ sender: Any) {
-        guard let selectedIndex = tableViewList.indexPathForSelectedRow,
-              let cell = tableViewList.cellForRow(at: selectedIndex) as? ListTableViewCell else { return }
-        
-        viewModel.resultAction(cell.gdsLocalisedString)
         viewModel.buttonViewModel.action()
     }
     
@@ -169,5 +165,8 @@ extension GDSListOptionsViewController: UITableViewDelegate {
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         primaryButton.isEnabled = true
+        if let cell = tableViewList.cellForRow(at: indexPath) as? ListTableViewCell {
+            viewModel.resultAction(cell.gdsLocalisedString)
+        }
     }
 }


### PR DESCRIPTION
# Refactoring list option view

This PR moved where the result action is called, moving from the primary button action into the `didSelect` table view delegate methods so it is no longer tied to primary button.  

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] ~Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [ ] ~ Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] ~Ran the app and tested the feature on a range of device sizes~
      ~Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

- [ ] ~Met all accessibility requirements?~
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code ~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
