### PR TITLE
fix: updated spacing to 16

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSListOptions/GDSListOptions.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSListOptions/GDSListOptions.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -32,10 +31,10 @@
                     <rect key="frame" x="0.0" y="59" width="393" height="629"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="89O-HG-BkV">
-                            <rect key="frame" x="0.0" y="0.0" width="393" height="508.33333333333331"/>
+                            <rect key="frame" x="0.0" y="0.0" width="393" height="523.33333333333337"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Cyo-Rv-pRC">
-                                    <rect key="frame" x="0.0" y="8" width="393" height="185"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Cyo-Rv-pRC">
+                                    <rect key="frame" x="0.0" y="8" width="393" height="189"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What device did you use to view the GOV.UK website?" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yxl-C7-PMp">
                                             <rect key="frame" x="16" y="0.0" width="361" height="122.66666666666667"/>
@@ -47,7 +46,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To finish linking the app, we need to know what device you used to view the GOV.UK website." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N4x-de-I0h">
-                                            <rect key="frame" x="16" y="134.66666666666666" width="361" height="42.333333333333343"/>
+                                            <rect key="frame" x="16" y="138.66666666666666" width="361" height="42.333333333333343"/>
                                             <accessibility key="accessibilityConfiguration">
                                                 <accessibilityTraits key="traits" staticText="YES" header="YES"/>
                                             </accessibility>
@@ -59,10 +58,10 @@
                                     <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="8" right="16"/>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OHU-i7-Z4n">
-                                    <rect key="frame" x="0.0" y="209" width="393" height="200"/>
+                                    <rect key="frame" x="0.0" y="213" width="393" height="200"/>
                                 </stackView>
-                                <stackView autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3ma-59-6yV">
-                                    <rect key="frame" x="0.0" y="425" width="393" height="75.333333333333314"/>
+                                <stackView autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="3ma-59-6yV">
+                                    <rect key="frame" x="0.0" y="429" width="393" height="86.333333333333371"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ozk-0t-nU1">
                                             <rect key="frame" x="16" y="0.0" width="361" height="20.333333333333332"/>
@@ -71,7 +70,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="xFT-7W-y3G">
-                                            <rect key="frame" x="0.0" y="25.333333333333314" width="393" height="50"/>
+                                            <rect key="frame" x="0.0" y="36.333333333333371" width="393" height="50"/>
                                         </tableView>
                                     </subviews>
                                     <constraints>
@@ -84,7 +83,7 @@
                             <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="0.0" bottom="8" trailing="0.0"/>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="axh-CZ-aV7" userLabel="FooterLabel">
-                            <rect key="frame" x="16" y="508.33333333333343" width="361" height="15.666666666666686"/>
+                            <rect key="frame" x="16" y="523.33333333333337" width="361" height="15.666666666666629"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>


### PR DESCRIPTION
# DCMAW-5053 Select a document type (NFC)

Through Design QA it was identified that the spacing in the list view is not correct and did not follow the Figma designs. This PR updates the spacing in the `GDSListOptions` view. 

Previously the stack used to display the `title` and `body` text had a spacing of 12, it is now 16.
Previously the stack used to display the `tableTitle` and `table` had a spacing of 5, it is now 16.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] ~Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [] ~Written Unit and Integration tests if needed~

- [] Met all accessibility requirements?
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
