### PR TITLE
fix: disable/enable intro view button

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -84,7 +84,7 @@ extension IntroViewControllerTests {
         try sut.introButton.sendActions(for: .touchUpInside)
         XCTAssertFalse(try sut.introButton.isEnabled)
         XCTAssertTrue(buttonAction)
-        sut.enableContinueButton()
+        sut.enableIntroButton()
         XCTAssertTrue(try sut.introButton.isEnabled)
     }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -82,7 +82,10 @@ extension IntroViewControllerTests {
     func test_buttonAction() throws {
         XCTAssertFalse(buttonAction)
         try sut.introButton.sendActions(for: .touchUpInside)
+        XCTAssertFalse(try sut.introButton.isEnabled)
         XCTAssertTrue(buttonAction)
+        sut.enableContinueButton()
+        XCTAssertTrue(try sut.introButton.isEnabled)
     }
     
     func test_viewDidAppear() throws {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroView.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroView.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -88,7 +87,7 @@
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" title="Continue"/>
                             <connections>
-                                <action selector="didTapContinueButton" destination="-1" eventType="touchUpInside" id="WjL-DB-owU"/>
+                                <action selector="introButtonAction" destination="-1" eventType="touchUpInside" id="WjL-DB-owU"/>
                             </connections>
                         </button>
                     </subviews>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
@@ -57,6 +57,9 @@ public final class IntroViewController: BaseViewController, TitledViewController
     @IBAction private func didTapContinueButton() {
         introButton.isLoading = true
         viewModel.introButtonViewModel.action()
+    }
+    
+    public func enableContinueButton() {
         introButton.isLoading = false
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/IntroView/IntroViewController.swift
@@ -54,12 +54,12 @@ public final class IntroViewController: BaseViewController, TitledViewController
         }
     }
 
-    @IBAction private func didTapContinueButton() {
+    @IBAction private func introButtonAction() {
         introButton.isLoading = true
         viewModel.introButtonViewModel.action()
     }
     
-    public func enableContinueButton() {
+    public func enableIntroButton() {
         introButton.isLoading = false
     }
 }


### PR DESCRIPTION
# DCMAW-8928: iOS | Disable and add loading icon to Sign In button

Disabling/enabling the intro view button has not been working since this screen was added to the package, this PR addresses that adding a public method to disable the loading state of the button.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
