### PR TITLE
feat: add equatable conformance to GDSLocalisedString

### DIFF
--- a/Sources/GDSCommon/Utilities/GDSLocalisedString.swift
+++ b/Sources/GDSCommon/Utilities/GDSLocalisedString.swift
@@ -84,3 +84,11 @@ extension GDSLocalisedString: CustomStringConvertible {
         value
     }
 }
+
+extension GDSLocalisedString: Equatable {
+    public static func == (lhs: GDSLocalisedString, rhs: GDSLocalisedString) -> Bool {
+        lhs.stringKey == rhs.stringKey &&
+        lhs.variableKeys == rhs.variableKeys &&
+        lhs.bundle == rhs.bundle
+    }
+}

--- a/Sources/GDSCommon/Utilities/GDSLocalisedString.swift
+++ b/Sources/GDSCommon/Utilities/GDSLocalisedString.swift
@@ -89,6 +89,16 @@ extension GDSLocalisedString: Equatable {
     public static func == (lhs: GDSLocalisedString, rhs: GDSLocalisedString) -> Bool {
         lhs.stringKey == rhs.stringKey &&
         lhs.variableKeys == rhs.variableKeys &&
-        lhs.bundle == rhs.bundle
+        lhs.bundle == rhs.bundle &&
+        compare(lhs: lhs.attributes, to: rhs.attributes)
+    }
+    
+    private static func compare(lhs: Attributes?, to rhs: Attributes?) -> Bool {
+        let isSameLength = lhs?.count == rhs?.count
+        let zipped = zip(lhs ?? [], rhs ?? [])
+        return zipped
+            .allSatisfy { lhsAttribute, rhsAttribute in
+                lhsAttribute.0 == rhsAttribute.0
+            } && isSameLength
     }
 }

--- a/Tests/GDSCommonTests/GDSLocalisedStringTests.swift
+++ b/Tests/GDSCommonTests/GDSLocalisedStringTests.swift
@@ -81,4 +81,13 @@ extension GDSLocalisedStringTests {
         XCTAssertNotEqual(stringOne, stringTwo)
         XCTAssertNotEqual(stringOne, stringThree)
     }
+    
+    func test_equatableAttributes() {
+        let stringOne = GDSLocalisedString(stringKey: "firstNonStringLiteral",
+                                           attributes: [("one", [NSAttributedString.Key.foregroundColor: UIColor.red.cgColor])])
+        XCTAssertEqual(stringOne, stringOne)
+        
+        let stringTwo = GDSLocalisedString(stringKey: "firstNonStringLiteral")
+        XCTAssertNotEqual(stringOne, stringTwo)
+    }
 }

--- a/Tests/GDSCommonTests/GDSLocalisedStringTests.swift
+++ b/Tests/GDSCommonTests/GDSLocalisedStringTests.swift
@@ -70,3 +70,15 @@ extension GDSLocalisedStringTests {
         XCTAssertNil(sut.attributedValue)
     }
 }
+
+extension GDSLocalisedStringTests {
+    func test_equatable() {
+        let stringOne = GDSLocalisedString(stringKey: "firstNonStringLiteral", "one", "two", "three")
+        XCTAssertEqual(stringOne, stringOne)
+        
+        let stringTwo = GDSLocalisedString(stringKey: "secondNonStringLiteral", "one", "two", "three")
+        let stringThree = GDSLocalisedString(stringKey: "firstNonStringLiteral", "one", "two", "three", "four")
+        XCTAssertNotEqual(stringOne, stringTwo)
+        XCTAssertNotEqual(stringOne, stringThree)
+    }
+}


### PR DESCRIPTION
# feat: add equatable conformance to GDSLocalisedString

**DCMAW-9219**

GDSLocalisedString now conforms to equatable so it can be compared:

```swift
let stringOne = GDSLocalisedString(stringKey: "firstNonStringLiteral", "one", "two", "three")
let stringTwo = GDSLocalisedString(stringKey: "secondNonStringLiteral", "one", "two", "three")

if stringOne == stringTwo {
    // do something
}
```

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] ~~Met all accessibility requirements?~~
    - [ ] ~~Checked dynamic type sizes are applied~~
    - [ ] ~~Checked VoiceOver can navigate your new code~~
    - [ ] ~~Checked a user can navigate only using a keyboard around your new code ~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
