### PR TITLE
chore: added missing tests for primary button icon in modal info view

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -44,6 +44,7 @@ extension ModalInfoViewControllerTests {
         sut = ModalInfoViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button")
+        XCTAssertNil((try sut.primaryButton as? RoundedButton)?.icon)
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary button")
         XCTAssertTrue(sut.isModalInPresentation)
         
@@ -65,6 +66,22 @@ extension ModalInfoViewControllerTests {
         sut = ModalInfoViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.bodyLabel.attributedText?.string, "We can use this attribubted text if we want the user to complete an action")
+    }
+    
+    func test_primaryButtonIcon() throws {
+        viewModel = MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel(title: "Primary button",
+                                                                                              icon: MockButtonIconViewModel(),
+                                                                                              action: { self.primaryButton = true }),
+                                                  secondaryButtonViewModel: MockButtonViewModel(title: "Secondary button",
+                                                                                                icon: MockButtonIconViewModel(),
+                                                                                                action: { self.secondaryButton = true }),
+                                                  textButtonViewModel: MockButtonViewModel(title: "Text button",
+                                                                                           action: {self.textButton = true }))
+        
+        sut = ModalInfoViewController(viewModel: viewModel)
+        
+        let button = try sut.primaryButton as? RoundedButton
+        XCTAssertNotNil(button?.icon)
     }
 }
 


### PR DESCRIPTION
# Adds missing tests for primary button icon in modal info view

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
