### PR TITLE
feat: added inits to buttons to accept UIActions

### DIFF
--- a/Sources/GDSCommon/Components/Buttons/RoundedButton.swift
+++ b/Sources/GDSCommon/Components/Buttons/RoundedButton.swift
@@ -33,7 +33,14 @@ public final class RoundedButton: SecondaryButton {
         super.init(coder: aDecoder)
         gdsInit()
     }
-    
+
+    @available(iOS 14, *)
+    required public init(action: UIAction) {
+        super.init()
+
+        self.addAction(action, for: .touchUpInside)
+    }
+
     private let activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
         activityIndicator.style = .medium

--- a/Sources/GDSCommon/Components/Buttons/SecondaryButton.swift
+++ b/Sources/GDSCommon/Components/Buttons/SecondaryButton.swift
@@ -28,6 +28,13 @@ public class SecondaryButton: UIButton {
         commonInit()
     }
     
+    @available(iOS 14, *)
+    required public init(action: UIAction) {
+        super.init(frame: .zero)
+        
+        self.addAction(action, for: .touchUpInside)
+    }
+    
     private func commonInit() {
         titleLabel?.numberOfLines = 0
         titleLabel?.lineBreakMode = .byWordWrapping


### PR DESCRIPTION
# GOVUKAPP-491: Added initialiser for subclass of UIButton to accept UIActions

Because the `addAction` method is iOS 14+ the initialisers are marked as `@available(iOS 14, *)`

The addition of these initialisers allow for configuring the actions of buttons using `UIAction` instead of the traditional `target` / `#selector` approach.

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
