### PR TITLE
fix: added mainactor annotations to viewmodels

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -11,6 +11,7 @@ import UIKit
 /// - Returns: - The view name as a `String`
 ///             isModal as a `Bool` to determine if it should be presented modally, the default is false
 ///             the view as a `UIViewController` to push/present on the navigation stack.
+@MainActor
 enum Screens: String, CaseIterable {
     case gdsInstructions = "GDS Instructions View"
     case gdsInstructionsWithColouredButton = "GDS Instructions View (with coloured button)"
@@ -102,8 +103,10 @@ enum Screens: String, CaseIterable {
         case .gdsQRCodeScannerModal:
             let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) } dismissAction: {}
             return ScanningViewController(viewModel: viewModel)
-        case .gdsResultsView, .gdsResultsViewModal:
-            return ResultsViewController(popToRoot: self == .gdsResultsView ? popToRoot : nil, navController: navigationController)
+        case .gdsResultsView:
+            return ResultsViewController(popToRoot: popToRoot, navController: navigationController)
+        case .gdsResultsViewModal:
+            return ResultsViewController(popToRoot: nil, navController: navigationController)
         case .gdsErrorView:
             return GDSErrorViewController(viewModel: MockErrorViewModel())
         case .gdsInformationView:

--- a/GDSCommon-Demo/GDSCommon-DemoTests/DatePickerScreenViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/DatePickerScreenViewControllerTests.swift
@@ -16,6 +16,7 @@ final class DatePickerScreenViewControllerTests: XCTestCase {
     var didTapButton = false
     var didDismissScreen = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         gdsLocalisedString = "exampleString"
@@ -56,6 +57,7 @@ final class DatePickerScreenViewControllerTests: XCTestCase {
 
 @available(iOS 13.4, *)
 extension DatePickerScreenViewControllerTests {
+    @MainActor
     func testScreenAppears() {
         XCTAssertFalse(screenDidAppear)
         sut.beginAppearanceTransition(true, animated: false)
@@ -69,6 +71,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertNil(sut.viewModel.datePickerViewModel.selectedDate)
     }
     
+    @MainActor
     func testScreenAppears_ButtonDisabled() {
         datePickerVM = ReusableDatePickerViewModel(minDate: nil,
                                                    maxDate: nil)
@@ -87,6 +90,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertFalse(try sut.primaryButton.isEnabled)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
@@ -96,6 +100,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertEqual(view.text, "Date picker screen title")
     }
     
+    @MainActor
     func testLabelContents() {
         XCTAssertEqual(try sut.titleLabel.text, "Date picker screen title")
         XCTAssertEqual(try sut.titleLabel.font, .largeTitleBold)
@@ -105,6 +110,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertEqual(try sut.footerLabel.text, "Example date picker footer")
     }
     
+    @MainActor
     func testTitleBar() {
         XCTAssertEqual(sut.navigationItem.hidesBackButton, false)
         sut.navigationItem.hidesBackButton = true
@@ -120,6 +126,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertTrue(didDismissScreen)
     }
     
+    @MainActor
     func testPrimaryButton() throws {
         datePickerVM = ReusableDatePickerViewModel(minDate: Date(),
                                                    maxDate: nil,
@@ -149,6 +156,7 @@ extension DatePickerScreenViewControllerTests {
         XCTAssertFalse(didTapButton)
     }
     
+    @MainActor
     func testPrimaryButton_ButtonActive() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -9,6 +9,7 @@ final class GDSErrorViewControllerTests: XCTestCase {
     var viewDidAppear = false
     var viewDidDismiss = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -100,6 +101,7 @@ extension GDSErrorViewControllerTests {
         XCTAssertTrue(viewDidAppear)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
@@ -13,6 +13,7 @@ final class GDSInformationViewControllerTests: XCTestCase {
     var viewDidAppear = false
     var viewDidDismiss = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -57,16 +58,19 @@ extension GDSInformationViewControllerTests {
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Information secondary button title")
     }
     
+    @MainActor
     func test_primaryButtonNoIcon() throws {
         XCTAssertNil(viewModel.primaryButtonViewModel.icon)
         XCTAssertNil(try sut.primaryButton.icon)
     }
 
+    @MainActor
     func test_secondaryButtonNoIcon() throws {
         XCTAssertNil(viewModel.secondaryButtonViewModel?.icon)
         XCTAssertNil(try sut.secondaryButton.icon)
     }
     
+    @MainActor
     func test_secondaryButtonWithIcon() throws {
         secondaryButtonViewModel = MockButtonViewModel(title: "Information secondary button title",
                                                        icon: MockButtonIconViewModel()) {}
@@ -97,7 +101,8 @@ extension GDSInformationViewControllerTests {
         sut.endAppearanceTransition()
         XCTAssertTrue(viewDidAppear)
     }
-    
+
+    @MainActor
     func test_voiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -1,7 +1,6 @@
 import GDSCommon
 import XCTest
 
-@MainActor
 final class GDSInstructionsViewControllerTests: XCTestCase {
     var buttonViewModel: ButtonViewModel!
     var viewModel: GDSInstructionsViewModel!
@@ -12,6 +11,7 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
     var didTapButton = false
     var didDismiss = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -34,7 +34,7 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
         
         sut = GDSInstructionsViewController(viewModel: viewModel)
     }
-    
+
     override func tearDown() {
         buttonViewModel = nil
         bulletView = nil
@@ -52,6 +52,7 @@ extension GDSInstructionsViewControllerTests {
         XCTAssertTrue(screenDidAppear)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
@@ -110,6 +111,7 @@ extension GDSInstructionsViewControllerTests {
         XCTAssertEqual(try sut.primaryButton.backgroundColor, .gdsGreen)
     }
 
+    @MainActor
     func test_coloredButton() throws {
         let coloredButton = MockColoredButtonViewModel(title: "Test", action: { }, backgroundColor: .gdsRed)
         viewModel = MockGDSInstructionsViewModel(childView: bulletView, buttonViewModel: coloredButton, secondaryButtonViewModel: nil, screenView: { }) {

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSListOptionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSListOptionsViewControllerTests.swift
@@ -10,6 +10,7 @@ final class GDSListOptionsViewControllerTests: XCTestCase {
     var screenDidAppear: Bool!
     var didDismiss: Bool!
     
+    @MainActor
     override func setUp() {
         super.setUp()
         screenDidAppear = false
@@ -37,6 +38,7 @@ final class GDSListOptionsViewControllerTests: XCTestCase {
         super.tearDown()
     }
     
+    @MainActor
     private func setupSUTWithNilOptionals() {
         viewModel = MockListViewModel(childView: nil, secondaryButtonViewModel: nil, listTitle: nil) {
             self.screenDidAppear = true
@@ -65,6 +67,7 @@ extension GDSListOptionsViewControllerTests {
         XCTAssertNotNil(sut.navigationItem.rightBarButtonItem)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
@@ -110,6 +113,7 @@ extension GDSListOptionsViewControllerTests {
         XCTAssertTrue(didDismiss)
     }
     
+    @MainActor
     func testDidSelectTableViewSetsSelectedIndex() throws {
         XCTAssertEqual(viewModel.selectedIndex.stringKey, "")
         try sut.tableViewList.reloadData()
@@ -125,6 +129,7 @@ extension GDSListOptionsViewControllerTests {
         XCTAssertTrue(didDismiss)
     }
     
+    @MainActor
     func testContentHiddenWhenNil() throws {
         setupSUTWithNilOptionals()
         XCTAssertTrue(try sut.secondaryButton.isHidden)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -15,6 +15,7 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
     var didTapSecondaryButton = false
     var didTapWarningButton = false
 
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -59,6 +60,7 @@ extension InstructionsWithImageViewControllerTests {
         XCTAssertTrue(screenDidAppear)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
@@ -100,6 +102,7 @@ extension InstructionsWithImageViewControllerTests {
         XCTAssertNotNil(try sut.imageView)
     }
     
+    @MainActor
     func test_primaryButton() throws {
         XCTAssertNotNil(try sut.primaryButton)
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Action Button")
@@ -110,7 +113,8 @@ extension InstructionsWithImageViewControllerTests {
         try sut.primaryButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didTapPrimaryButton)
     }
-    
+
+    @MainActor
     func test_secondaryButton() throws {
         XCTAssertNotNil(try sut.secondaryButton)
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary Button")

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -8,6 +8,7 @@ final class IntroViewControllerTests: XCTestCase {
     var viewDidAppear = false
     var viewDidDismiss = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -70,6 +71,7 @@ extension IntroViewControllerTests {
         XCTAssertEqual(try sut.introButton.title(for: .normal), "Intro screen button title")
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -19,6 +19,7 @@ final class ModalInfoViewControllerTests: XCTestCase {
 }
 
 extension ModalInfoViewControllerTests {
+    @MainActor
     func test_modalInfoView() throws {
         viewModel = MockModalInfoViewModel()
         sut = ModalInfoViewController(viewModel: viewModel)
@@ -32,6 +33,7 @@ extension ModalInfoViewControllerTests {
         XCTAssertFalse(sut.isModalInPresentation)
     }
     
+    @MainActor
     func test_modalInfoViewButtons() throws {
         viewModel = MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel(title: "Primary button",
                                                                                               action: { self.primaryButton = true }),
@@ -61,6 +63,7 @@ extension ModalInfoViewControllerTests {
         XCTAssertTrue(textButton)
     }
     
+    @MainActor
     func test_attributedModalInfoView() throws {
         viewModel = MockAttributedModalInfoViewModel()
         sut = ModalInfoViewController(viewModel: viewModel)
@@ -68,6 +71,7 @@ extension ModalInfoViewControllerTests {
         XCTAssertEqual(try sut.bodyLabel.attributedText?.string, "We can use this attribubted text if we want the user to complete an action")
     }
     
+    @MainActor
     func test_primaryButtonIcon() throws {
         viewModel = MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel(title: "Primary button",
                                                                                               icon: MockButtonIconViewModel(),

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ResultsViewControllerTests.swift
@@ -8,6 +8,7 @@ final class ResultsViewControllerTests: XCTestCase {
     var screenDidAppear = false
     var screenDidDismiss = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -19,7 +20,7 @@ final class ResultsViewControllerTests: XCTestCase {
         
         sut = ResultsViewController(viewModel: viewModel)
     }
-    
+
     override func tearDown() {
         viewModel = nil
         sut = nil
@@ -63,6 +64,7 @@ extension ResultsViewControllerTests {
         XCTAssertTrue(screenDidAppear)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
@@ -72,6 +74,7 @@ extension ResultsViewControllerTests {
         XCTAssertEqual(view.text, "Results title")
     }
     
+    @MainActor
     func test_labelContents() throws {
         XCTAssertEqual(sut.viewModel.image, "checkmark.circle")
         XCTAssertEqual(try sut.titleLabel.text, "Results title")

--- a/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/TextInputViewControllerTests.swift
@@ -14,6 +14,7 @@ final class TextInputViewControllerTests: XCTestCase {
     var didTapButton = false
     var didDismissScreen = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
 
@@ -22,8 +23,6 @@ final class TextInputViewControllerTests: XCTestCase {
         resultAction = { bool in
             self.didSetResult.append(bool)
         }
-        
-        let textFieldViewModel = MockTextFieldViewModel<InputType>()
         
         let viewModel = MockTextInputViewModel<InputType> { result in
             self.didSetResult = [result]
@@ -58,6 +57,7 @@ extension TextInputViewControllerTests {
         XCTAssertTrue(screenDidAppear)
     }
     
+    @MainActor
     func testVoiceOverFocusElement() throws {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()

--- a/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
+++ b/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 public protocol BulletViewModel {
     var title: String? { get }
     var titleFont: UIFont? { get }

--- a/Sources/GDSCommon/Components/Buttons/ButtonIconViewModel.swift
+++ b/Sources/GDSCommon/Components/Buttons/ButtonIconViewModel.swift
@@ -1,3 +1,4 @@
+@MainActor
 public protocol ButtonIconViewModel {
     var iconName: String { get }
     var symbolPosition: SymbolPosition { get }

--- a/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
+++ b/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 public protocol ButtonViewModel {
     var title: GDSLocalisedString { get }
     var icon: ButtonIconViewModel? { get }

--- a/Sources/GDSCommon/Components/Buttons/PageButtonViewModels.swift
+++ b/Sources/GDSCommon/Components/Buttons/PageButtonViewModels.swift
@@ -1,17 +1,20 @@
 /// View model for the views with a primary button
 /// - `primaryButtonViewModel` type is ``ButtonViewModel``
+@MainActor
 public protocol PageWithPrimaryButtonViewModel {
     var primaryButtonViewModel: ButtonViewModel { get }
 }
 
 /// View model for the views with a secondary button
 /// - `secondaryButtonViewModel` type is ``ButtonViewModel``
+@MainActor
 public protocol PageWithSecondaryButtonViewModel {
     var secondaryButtonViewModel: ButtonViewModel { get }
 }
 
 /// View model for the views with a button that displays as text i.e privacy policy
 ///  - `textButtonViewModel` type is ``ButtonViewModel``
+@MainActor
 public protocol PageWithTextButtonViewModel {
     var textButtonViewModel: ButtonViewModel { get }
 }

--- a/Sources/GDSCommon/Components/Buttons/SwiftUI/ButtonInfoViewModel.swift
+++ b/Sources/GDSCommon/Components/Buttons/SwiftUI/ButtonInfoViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 public protocol ButtonInfoViewModel {
     var title: String { get }
     var body: String { get }

--- a/Sources/GDSCommon/Components/DatePickerViewModel.swift
+++ b/Sources/GDSCommon/Components/DatePickerViewModel.swift
@@ -6,6 +6,7 @@ import UIKit
 /// the earliest or latest dates selectable from the date picker.
 /// Additionally, there is a `setSelectedDate` method for setting `selectedDate`
 @available(iOS 13.4, *)
+@MainActor
 public protocol DatePickerViewModel {
     var pickerStyle: UIDatePickerStyle { get }
     var selectedDate: Date? { get set }

--- a/Sources/GDSCommon/Components/ReusableDatePickerViewModel.swift
+++ b/Sources/GDSCommon/Components/ReusableDatePickerViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Concrete implementation of `DatePickerViewModel`
+@MainActor
 struct ReusableDatePickerViewModel: DatePickerViewModel {
     let minDate: Date?
     let maxDate: Date?

--- a/Sources/GDSCommon/Patterns/BaseViewModel.swift
+++ b/Sources/GDSCommon/Patterns/BaseViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 public protocol BaseViewModel {
     var rightBarButtonTitle: GDSLocalisedString? { get }
     var backButtonIsHidden: Bool { get }

--- a/Sources/GDSCommon/Patterns/DatePicker/DatePickerScreenViewModel.swift
+++ b/Sources/GDSCommon/Patterns/DatePicker/DatePickerScreenViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 /// include logging screen analytics or loading content from an endpoint for example.
 /// The `result` closure returns the selected date.
 @available(iOS 13.4, *)
+@MainActor
 public protocol DatePickerScreenViewModel {
     var title: GDSLocalisedString { get }
     var datePickerViewModel: DatePickerViewModel { get set }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// Protocol for the view model required to initilise ``ErrorViewModel``
+@MainActor
 public protocol GDSErrorViewModel {
     var image: String { get }
     var title: GDSLocalisedString { get }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModel.swift
@@ -20,6 +20,7 @@ import UIKit
 /// screens modally and calling custom methods when screens appear and dismiss.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
+@MainActor
 public protocol GDSInformationViewModel {
     var image: String { get }
     var imageWeight: UIFont.Weight? { get }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 ///
 /// `childView` is added at the bottom of the `stackView` that contains the `title` and
 /// `body`. Because it is of type `UIView` the kind of view that can be added here is very flexible.
+@MainActor
 public protocol GDSInstructionsViewModel {
     var title: GDSLocalisedString { get }
     var body: String { get }

--- a/Sources/GDSCommon/Patterns/GDSListOptions/GDSListOptionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSListOptions/GDSListOptionsViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 /// Protocol for the view model required to initilise a ``ListOptionsViewController``
+@MainActor
 public protocol GDSListOptionsViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString? { get }

--- a/Sources/GDSCommon/Patterns/GDSLoadingScreen/GDSLoadingViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSLoadingScreen/GDSLoadingViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 /// screens modally and calling custom methods when screens appear and dismiss.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
+@MainActor
 public protocol GDSLoadingViewModel {
     var loadingLabelKey: GDSLocalisedString { get }
 }

--- a/Sources/GDSCommon/Patterns/IconScreenView/IconScreenViewModel.swift
+++ b/Sources/GDSCommon/Patterns/IconScreenView/IconScreenViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
+@MainActor
 public protocol IconScreenViewModel {
     var imageName: String { get }
     var title: GDSLocalisedString { get }

--- a/Sources/GDSCommon/Patterns/IconScreenView/OptionViewModel.swift
+++ b/Sources/GDSCommon/Patterns/IconScreenView/OptionViewModel.swift
@@ -2,6 +2,7 @@
 /// - `title` type is ``GDSLocalisedString``
 /// - `subtitle` type is ``GDSLocalisedString``
 /// - `buttonViewModel` type is ``ButtonViewModel``
+@MainActor
 public protocol OptionViewModel {
     var title: GDSLocalisedString { get }
     var subtitle: GDSLocalisedString { get }

--- a/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -6,6 +6,7 @@ import UIKit
 /// - `image` type is `UIImage`
 /// - `warningButtonViewModel` type is ``ButtonViewModel``?
 /// - `primaryButtonViewModel` type is ``ButtonViewModel``
+@MainActor
 public protocol InstructionsWithImageViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }

--- a/Sources/GDSCommon/Patterns/IntroView/IntroViewModel.swift
+++ b/Sources/GDSCommon/Patterns/IntroView/IntroViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// Protocol for the view model required to initilise a ``IntroViewController``
+@MainActor
 public protocol IntroViewModel {
     var image: UIImage { get }
     var title: GDSLocalisedString { get }

--- a/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewModel.swift
+++ b/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewModel.swift
@@ -4,6 +4,7 @@ import UIKit
 /// - `title` type is ``GDSLocalisedString``
 /// - `body` type is ``GDSLocalisedString``
 /// - `bodyTextColour` type is ``UIColor``
+@MainActor
 public protocol ModalInfoViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
@@ -12,6 +13,7 @@ public protocol ModalInfoViewModel {
 
 /// View model for extra configuration on the `ModalInfoViewController`
 /// - `preventModalDismiss` type is ``Bool``
+@MainActor
 public protocol ModalInfoExtraViewModel {
     var preventModalDismiss: Bool { get }
 }

--- a/Sources/GDSCommon/Patterns/Popover/PopoverViewModel.swift
+++ b/Sources/GDSCommon/Patterns/Popover/PopoverViewModel.swift
@@ -6,7 +6,7 @@ import UIKit
 /// - `icon` type is ``String``
 /// - `tint` type is ``UIColor``
 /// - `action` type is ``() -> Void``
-
+@MainActor
 public protocol PopoverItemViewModel {
     var title: String { get }
     var titleFont: UIFont { get }

--- a/Sources/GDSCommon/Patterns/Results/ResultsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/Results/ResultsViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// Protocol for the view model required to initilise a ``ResultsViewController``
+@MainActor
 public protocol ResultsViewModel {
     var image: String { get }
     var title: GDSLocalisedString { get }

--- a/Sources/GDSCommon/Patterns/Scanner/QRScanningViewModel.swift
+++ b/Sources/GDSCommon/Patterns/Scanner/QRScanningViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 public protocol QRScanningViewModel {
     var title: String { get }
     var instructionText: String { get }

--- a/Sources/GDSCommon/Patterns/TextInput/TextFieldViewModel.swift
+++ b/Sources/GDSCommon/Patterns/TextInput/TextFieldViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 /// `TextFieldViewModel` use to configure `UITextField`. Create a concrete implementation
 /// is required in order to initialise a`TextInputViewModel`
 /// The `validator` method can be used to validate the text field input each time the text changes.
+@MainActor
 public protocol TextFieldViewModel {
     var keyboardType: UIKeyboardType { get }
     var placeholder: String? { get }

--- a/Sources/GDSCommon/Patterns/TextInput/TextInputViewModel.swift
+++ b/Sources/GDSCommon/Patterns/TextInput/TextInputViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 /// `TextInputViewModel` protocol to be used with `TextInputViewController`
+@MainActor
 public protocol TextInputViewModel {
     associatedtype InputType: LosslessStringConvertible
     

--- a/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
+++ b/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
@@ -3,6 +3,7 @@ import UIKit
 /// Conform view controllers that inhereit from ``BaseViewController`` to this protocol to benefit
 /// from setting the initial VoiceOver focus when the screen appears.
 /// The focus is directed by the `viewIsAppearing` lifecycle method.
+@MainActor
 public protocol VoiceOverFocus {
     var initialVoiceOverView: UIView { get }
 }
@@ -10,6 +11,7 @@ public protocol VoiceOverFocus {
 /// For screen view controllers within `GDSCommon` that have a ``titleLabel`` property and inherits
 /// from ``BaseViewController``, conform the view controller to ``TitledViewController`` to
 /// automaticaly direct VoiceOver to the ``titleLabel`` when the screen appears
+@MainActor
 protocol TitledViewController: VoiceOverFocus {
     var titleLabel: UILabel! { get }
 }

--- a/Tests/GDSCommonTests/ButtonStylesTests.swift
+++ b/Tests/GDSCommonTests/ButtonStylesTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class ButtonStylesTests: XCTestCase {}
 
 extension ButtonStylesTests {
+    @MainActor
     func test_primaryButton() throws {
         let sut = ButtonView(buttonViewModel: MockButtonViewModel(title: "", action: { }))
             .buttonStyle(.primary)
@@ -24,6 +25,7 @@ extension ButtonStylesTests {
         XCTAssertEqual(try Primary().inspect(isPressed: false).cornerRadius(), 16)
     }
     
+    @MainActor
     func test_secondaryButton() throws {
         let sut = ButtonView(buttonViewModel: MockButtonViewModel(title: "", action: { }))
             .buttonStyle(.secondary)
@@ -39,6 +41,7 @@ extension ButtonStylesTests {
         XCTAssertEqual(try Secondary().inspect(isPressed: false).flexFrame().minHeight, 44)
     }
     
+    @MainActor
     func test_supportButton() throws {
         let sut = ButtonView(buttonViewModel: MockButtonViewModel(title: "", action: { }))
             .buttonStyle(.support)

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -31,6 +31,7 @@ extension BulletViewTests {
         try XCTAssertTrue(sut.titleLabel.accessibilityTraits.contains(.header))
     }
     
+    @MainActor
     func test_initWithViewModel() {
         struct MockBulletViewModel: BulletViewModel {
             let title: String? = nil

--- a/Tests/GDSCommonTests/ComponentTests/ButtonInfoViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/ButtonInfoViewTests.swift
@@ -6,6 +6,7 @@ import XCTest
 final class ButtonInfoViewTests: XCTestCase {
     var sut: ButtonInfoView!
 
+    @MainActor
     override func setUp() {
         super.setUp()
 

--- a/Tests/GDSCommonTests/ComponentTests/DatePickerViewModelTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/DatePickerViewModelTests.swift
@@ -24,6 +24,7 @@ final class DatePickerViewModelTests: XCTestCase {
 
 @available(iOS 13.4, *)
 extension DatePickerViewModelTests {
+    @MainActor
     func testViewModel() throws {
         let selected = try XCTUnwrap(sut.selectedDate)
         XCTAssertTrue(Calendar.current.isDateInToday(selected))

--- a/Tests/GDSCommonTests/ComponentTests/DialogViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/DialogViewTests.swift
@@ -1,9 +1,7 @@
 @testable import GDSCommon
 import XCTest
 
-@MainActor
 final class DialogViewTests: XCTestCase {
-    
     private var sut: DialogView<CheckmarkDialogAccessoryView>!
     private var viewController: UIViewController!
     private var window: UIWindow!

--- a/Tests/GDSCommonTests/ComponentTests/PopoverTableViewCellTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/PopoverTableViewCellTests.swift
@@ -6,6 +6,7 @@ final class PopoverTableViewCellTests: XCTestCase {
     
     var didSelectItem: Bool = false
     
+    @MainActor
     override func setUp() {
         super.setUp()
         


### PR DESCRIPTION
# fix: added mainactor annotations to viewmodels

DCMAW-9459

View Models run on the main thread and should therefore be annotated as `@MainActor`.
This adds `@MainActor` annotations to all of the view model protocols in this repository.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
