### PR TITLE
feat: updated ErrorView with a third button

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -15,7 +15,7 @@ struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
     func didDismiss() {}
 }
 
-struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSTertiaryButtonViewModel {
+struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -14,3 +14,18 @@ struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
     
     func didDismiss() {}
 }
+
+struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSTertiaryButtonViewModel {
+    let image: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
+    let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
+    let secondaryButtonViewModel: ButtonViewModel? = MockButtonViewModel.secondary
+    let tertiaryButtonViewModel: ButtonViewModel = MockButtonViewModel.secondary
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    func didAppear() {}
+    
+    func didDismiss() {}
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -30,6 +30,7 @@ enum Screens: String, CaseIterable {
     case gdsResultsView = "Results View"
     case gdsResultsViewModal = "Results View (Modal)"
     case gdsErrorView = "Error View"
+    case gdsErrorViewWithTertiary = "Error View (with 3 buttons)"
     case gdsInformationView = "Information View"
     case gdsLoadingView = "GDS Loading View"
 
@@ -109,6 +110,8 @@ enum Screens: String, CaseIterable {
             return ResultsViewController(popToRoot: nil, navController: navigationController)
         case .gdsErrorView:
             return GDSErrorViewController(viewModel: MockErrorViewModel())
+        case .gdsErrorViewWithTertiary:
+            return GDSErrorViewController(viewModel: MockErrorViewModelWithTertiary())
         case .gdsInformationView:
             return GDSInformationViewController()
         case .gdsLoadingView:

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -70,7 +70,7 @@ private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
     }
 }
 
-private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSTertiaryButtonViewModel, BaseViewModel {
+private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -6,6 +6,7 @@ final class GDSErrorViewControllerTests: XCTestCase {
     var sut: GDSErrorViewController!
     var primaryButton = false
     var secondaryButton = false
+    var tertiaryButton = false
     var viewDidAppear = false
     var viewDidDismiss = false
     
@@ -39,7 +40,7 @@ private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
-
+    
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
     let backButtonIsHidden: Bool = false
     let appearAction: () -> Void
@@ -69,6 +70,47 @@ private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
     }
 }
 
+private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSTertiaryButtonViewModel, BaseViewModel {
+    let image: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "Error screen title"
+    let body: GDSLocalisedString = "Error screen body"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    let tertiaryButtonViewModel: ButtonViewModel
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let backButtonIsHidden: Bool = false
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    init(primaryButtonAction: @escaping () -> Void,
+         secondaryButtonAction: @escaping () -> Void,
+         tertiaryButtonAction: @escaping () -> Void,
+         appearAction: @escaping () -> Void,
+         dismissAction: @escaping () -> Void
+    ) {
+        primaryButtonViewModel = MockButtonViewModel(title: "Error primary button title") {
+            primaryButtonAction()
+        }
+        secondaryButtonViewModel = MockButtonViewModel(title: "Error secondary button title") {
+            secondaryButtonAction()
+        }
+        tertiaryButtonViewModel = MockButtonViewModel(title: "Error tertiary button title") {
+            tertiaryButtonAction()
+        }
+        self.appearAction = appearAction
+        self.dismissAction = dismissAction
+    }
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}
+
 extension GDSErrorViewControllerTests {
     func test_labelContents() throws {
         XCTAssertNotNil(try sut.errorImage)
@@ -79,6 +121,7 @@ extension GDSErrorViewControllerTests {
         XCTAssertFalse(try sut.errorBodyLabel.accessibilityTraits.contains(.header))
         XCTAssertEqual(try sut.errorPrimaryButton.title(for: .normal), "Error primary button title")
         XCTAssertEqual(try sut.errorSecondaryButton.title(for: .normal), "Error secondary button title")
+        XCTAssertTrue(try sut.errorTertiaryButton.isHidden)
     }
     
     func test_primaryButtonAction() throws {
@@ -91,6 +134,31 @@ extension GDSErrorViewControllerTests {
         XCTAssertFalse(secondaryButton)
         try sut.errorSecondaryButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(secondaryButton)
+    }
+    
+    func test_tertiaryButtonContentAndAction() throws {
+        viewModel = nil
+        sut = nil
+        
+        viewModel = TestViewModelWithTertiary {
+            self.primaryButton = true
+        } secondaryButtonAction: {
+            self.secondaryButton = true
+        } tertiaryButtonAction: {
+            self.tertiaryButton = true
+        } appearAction: {
+            self.viewDidAppear = true
+        } dismissAction: {
+            self.viewDidDismiss = true
+        }
+        sut = GDSErrorViewController(viewModel: viewModel)
+        
+        XCTAssertFalse(tertiaryButton)
+        try sut.errorTertiaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(tertiaryButton)
+        
+        XCTAssertFalse(try sut.errorTertiaryButton.isHidden)
+        XCTAssertEqual(try sut.errorTertiaryButton.title(for: .normal), "Error tertiary button title")
     }
     
     func test_didAppear() throws {
@@ -152,6 +220,12 @@ extension GDSErrorViewController {
     var errorSecondaryButton: UIButton {
         get throws {
             try XCTUnwrap(view[child: "error-secondary-button"])
+        }
+    }
+    
+    var errorTertiaryButton: UIButton {
+        get throws {
+            try XCTUnwrap(view[child: "error-tertiary-button"])
         }
     }
 }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -136,6 +136,7 @@ extension GDSErrorViewControllerTests {
         XCTAssertTrue(secondaryButton)
     }
     
+    @MainActor
     func test_tertiaryButtonContentAndAction() throws {
         viewModel = nil
         sut = nil

--- a/Sources/GDSCommon/Patterns/GDSError/GDSError.xib
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSError.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,6 +15,7 @@
                 <outlet property="errorImage" destination="vYf-gc-Vz7" id="bo0-HU-93z"/>
                 <outlet property="primaryButton" destination="c0j-S4-wib" id="iRa-Bu-gFu"/>
                 <outlet property="secondaryButton" destination="wHP-qw-frB" id="SoD-KK-dAU"/>
+                <outlet property="tertiaryButton" destination="ne9-NN-fqX" id="ASq-mE-U4M"/>
                 <outlet property="titleLabel" destination="K7u-1O-Xu6" id="Egg-4m-zff"/>
                 <outlet property="view" destination="PHp-iG-sgY" id="Bv0-6i-0Mc"/>
             </connections>
@@ -25,24 +26,24 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5qi-Vj-0S0">
-                    <rect key="frame" x="0.0" y="47" width="390" height="606"/>
+                    <rect key="frame" x="0.0" y="47" width="390" height="541"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="hBq-l6-RtC" userLabel="Stack View_outer">
-                            <rect key="frame" x="0.0" y="0.0" width="390" height="606"/>
+                            <rect key="frame" x="0.0" y="0.0" width="390" height="541"/>
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="358" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="oVM-B5-m8o">
-                                    <rect key="frame" x="16" y="8" width="358" height="167"/>
+                                    <rect key="frame" x="16" y="8" width="358" height="134.66666666666666"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 </view>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="exclamationmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="vYf-gc-Vz7">
-                                    <rect key="frame" x="16" y="200" width="358" height="105.66666666666669"/>
+                                    <rect key="frame" x="16" y="167.66666666666666" width="358" height="105.66666666666666"/>
                                     <color key="tintColor" systemColor="labelColor"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="107" id="hd0-hw-yhP"/>
                                     </constraints>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Yrg-7G-oGo" userLabel="Stack View_inner">
-                                    <rect key="frame" x="16" y="330" width="358" height="77"/>
+                                    <rect key="frame" x="16" y="297.66666666666669" width="358" height="77"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K7u-1O-Xu6">
                                             <rect key="frame" x="0.0" y="0.0" width="358" height="40.666666666666664"/>
@@ -54,7 +55,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GKc-km-TXE">
-                                            <rect key="frame" x="0.0" y="56.666666666666693" width="358" height="20.333333333333336"/>
+                                            <rect key="frame" x="0.0" y="56.666666666666636" width="358" height="20.333333333333336"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -62,7 +63,7 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="358" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="V2h-pW-19V">
-                                    <rect key="frame" x="16" y="431" width="358" height="167"/>
+                                    <rect key="frame" x="16" y="398.66666666666669" width="358" height="134.33333333333331"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 </view>
                             </subviews>
@@ -85,7 +86,7 @@
                     <viewLayoutGuide key="frameLayoutGuide" id="ira-NN-kvX"/>
                 </scrollView>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="500" verticalCompressionResistancePriority="1000" axis="vertical" spacing="21" translatesAutoresizingMaskIntoConstraints="NO" id="KzI-zC-aFB" userLabel="Stack View_button">
-                    <rect key="frame" x="0.0" y="669" width="390" height="125"/>
+                    <rect key="frame" x="0.0" y="604" width="390" height="190"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" verticalHuggingPriority="500" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="358" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c0j-S4-wib" customClass="RoundedButton" customModule="GDSCommon">
                             <rect key="frame" x="16" y="8" width="358" height="44"/>
@@ -107,6 +108,19 @@
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="secondaryButtonAction:" destination="-1" eventType="touchUpInside" id="pau-qj-fmb"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" verticalHuggingPriority="500" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="326" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ne9-NN-fqX" customClass="SecondaryButton" customModule="GDSCommon">
+                            <rect key="frame" x="16" y="138" width="358" height="44"/>
+                            <accessibility key="accessibilityConfiguration" identifier="exit-button"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Tertiary Button"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="icon" value="arrow.up.right"/>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="tertiaryButtonAction:" destination="-1" eventType="touchUpInside" id="FdE-W1-34q"/>
                             </connections>
                         </button>
                     </subviews>

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -83,10 +83,12 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
         didSet {
             if let buttonViewModel = (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel {
                 tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
-                tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
+                
             } else {
                 tertiaryButton.isHidden = true
             }
+            
+            tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
         }
     }
     

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 ///     - `bodyLabel` (type: `UILabel`)
 ///     - `primaryButton`  (type: ``RoundedButton`` inherits from ``SecondaryButton``)
 ///     - `secondaryButton`  (type: ``SecondaryButton`` inherits from ``UIButton``)
+///     - `tertiaryButton` (type: ``SecondaryButton`` inherits from ``UIButton``)
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     
@@ -78,21 +79,18 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
         viewModel.secondaryButtonViewModel?.action()
     }
     
-    @IBOutlet weak var tertiaryButton: SecondaryButton! {
+    @IBOutlet private var tertiaryButton: SecondaryButton! {
         didSet {
-            if let buttonViewModel = (viewModel as? GDSTertiaryButtonViewModel)?
-                .tertiaryButtonViewModel {
+            if let buttonViewModel = (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel {
                 tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
+                tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
             } else {
                 tertiaryButton.isHidden = true
             }
-            
-            tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
         }
     }
     
-    @IBAction func tertiaryButtonAction(_ sender: Any) {
+    @IBAction private func tertiaryButtonAction(_ sender: Any) {
         (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
     }
-    
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -10,7 +10,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     public override var nibName: String? { "GDSError" }
     
     public private(set) var viewModel: GDSErrorViewModel
-
+    
     public init(viewModel: GDSErrorViewModel) {
         self.viewModel = viewModel
         super.init(viewModel: viewModel as? BaseViewModel, nibName: "GDSError", bundle: .module)
@@ -44,7 +44,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
             bodyLabel.accessibilityIdentifier = "error-body"
         }
     }
-
+    
     @IBOutlet private var primaryButton: RoundedButton! {
         didSet {
             primaryButton.setTitle(viewModel.primaryButtonViewModel.title, for: .normal)
@@ -77,4 +77,22 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     @IBAction private func secondaryButtonAction(_ sender: Any) {
         viewModel.secondaryButtonViewModel?.action()
     }
+    
+    @IBOutlet weak var tertiaryButton: SecondaryButton! {
+        didSet {
+            if let buttonViewModel = (viewModel as? GDSTertiaryButtonViewModel)?
+                .tertiaryButtonViewModel {
+                tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
+            } else {
+                tertiaryButton.isHidden = true
+            }
+            
+            tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
+        }
+    }
+    
+    @IBAction func tertiaryButtonAction(_ sender: Any) {
+        (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
+    }
+    
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -81,7 +81,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     
     @IBOutlet private var tertiaryButton: SecondaryButton! {
         didSet {
-            if let buttonViewModel = (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel {
+            if let buttonViewModel = (viewModel as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel {
                 tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
                 
             } else {
@@ -93,6 +93,6 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     }
     
     @IBAction private func tertiaryButtonAction(_ sender: Any) {
-        (viewModel as? GDSTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
+        (viewModel as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -12,6 +12,6 @@ public protocol GDSErrorViewModel {
 
 /// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
 @MainActor
-public protocol GDSTertiaryButtonViewModel {
+public protocol GDSScreenWithTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -9,3 +9,7 @@ public protocol GDSErrorViewModel {
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
+
+public protocol GDSTertiaryButtonViewModel {
+    var tertiaryButtonViewModel: ButtonViewModel { get }
+}

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -10,6 +10,7 @@ public protocol GDSErrorViewModel {
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
 
+/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
 public protocol GDSTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -11,6 +11,7 @@ public protocol GDSErrorViewModel {
 }
 
 /// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
+@MainActor
 public protocol GDSTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }
 }

--- a/Sources/GDSCommon/Patterns/README.md
+++ b/Sources/GDSCommon/Patterns/README.md
@@ -232,15 +232,16 @@ The content on the screen is set from the `viewModel`, which must conform to the
 
 ## GDSError
 
-This screen is typically used as an error screen, consisting of an alert icon, a title, body and the option of one or two buttons.
+This screen is typically used as an error screen, consisting of an alert icon, a title, body and the option of one, two or three buttons.
 A `UIStackView` holds the `errorImageView` and encases a second `UIStackView` which holds the `errorTitle` and `errorBody`. These views are placed within a `ScrollView`.
-The `primaryButton` and `secondaryButton` are placed in a `UIStackView`, below the `ScrollView`.
+The `primaryButton`, `secondaryButton` and `tertiaryButton` are placed in a `UIStackView`, below the `ScrollView`.
 
 `GDSErrorViewController` inherits from `BaseViewController`, so a navigation back button and right bar button can be configured. If this screen should be presented as a modal view, this should be done at the call site.
 
 A navigation item can be configured:
-- The `primaryButton`'s action is set from the ``primaryButtonViewModel`` in the viewModel.
-- The `secondaryButton`'s action is set from the ``secondaryButtonViewModel`` in the viewModel.
+- The `primaryButton`'s action is set from the ``primaryButtonViewModel`` in ``GDSErrorViewModel`` protocol.
+- The `secondaryButton`'s action is set from the ``secondaryButtonViewModel`` in ``GDSErrorViewModel`` protocol.
+- The `tertiaryButton`'s action is set from the ``tertiaryButtonViewModel` in ``GDSTertiaryButtonViewModel`` protocol.
 
 If the viewModel conforms to BaseViewModel:
 - A back button can be set via the `hideBackButton` boolean property on the view controller

--- a/Sources/GDSCommon/Patterns/README.md
+++ b/Sources/GDSCommon/Patterns/README.md
@@ -239,9 +239,9 @@ The `primaryButton`, `secondaryButton` and `tertiaryButton` are placed in a `UIS
 `GDSErrorViewController` inherits from `BaseViewController`, so a navigation back button and right bar button can be configured. If this screen should be presented as a modal view, this should be done at the call site.
 
 A navigation item can be configured:
-- The `primaryButton`'s action is set from the ``primaryButtonViewModel`` in ``GDSErrorViewModel`` protocol.
-- The `secondaryButton`'s action is set from the ``secondaryButtonViewModel`` in ``GDSErrorViewModel`` protocol.
-- The `tertiaryButton`'s action is set from the ``tertiaryButtonViewModel` in ``GDSTertiaryButtonViewModel`` protocol.
+- The `primaryButton`'s action is set from the ``primaryButtonViewModel`` in the ``GDSErrorViewModel`` protocol.
+- The `secondaryButton`'s action is set from the ``secondaryButtonViewModel`` in the ``GDSErrorViewModel`` protocol.
+- The `tertiaryButton`'s action is set from the ``tertiaryButtonViewModel` in the ``GDSTertiaryButtonViewModel`` protocol.
 
 If the viewModel conforms to BaseViewModel:
 - A back button can be set via the `hideBackButton` boolean property on the view controller


### PR DESCRIPTION
# DCMAW-7295 ID Check app to use Errors UI template in common repo

To update ID Check SDK to use the Common ErrorView we needed to update it with a third button. To avoid a breaking change a separate protocol has been made to set the third button

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
