### PR TITLE
feat: updating GDSError to optionally have icon

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct MockErrorViewModel: GDSErrorViewModelV2, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
@@ -28,7 +28,7 @@ struct MockErrorViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     func didDismiss() {}
 }
 
-struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
+struct MockErrorViewModelWithTertiary: GDSErrorViewModelV2, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -2,7 +2,21 @@ import GDSCommon
 import UIKit
 
 struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String = "exclamationmark.circle"
+    let image: String? = "exclamationmark.circle"
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
+    let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
+    let secondaryButtonViewModel: ButtonViewModel? = MockButtonViewModel.secondary
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    func didAppear() {}
+    
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
+    let image: String? = nil
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
@@ -16,7 +30,7 @@ struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
 }
 
 struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
-    let image: String = "exclamationmark.circle"
+    let image: String? = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -28,7 +28,7 @@ struct MockErrorViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     func didDismiss() {}
 }
 
-struct MockErrorViewModelWithTertiary: GDSErrorViewModelV2, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
+struct MockErrorViewModelWithTertiary: GDSErrorViewModelV2, GDSErrorViewModelWithImage, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-struct MockErrorViewModel: GDSErrorViewModelV2, BaseViewModel {
+struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSCommon
 import UIKit
 
 struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String? = "exclamationmark.circle"
+    let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
@@ -15,8 +15,7 @@ struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
     func didDismiss() {}
 }
 
-struct MockErrorViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
-    let image: String? = nil
+struct MockErrorViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
@@ -30,7 +29,7 @@ struct MockErrorViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
 }
 
 struct MockErrorViewModelWithTertiary: GDSErrorViewModel, BaseViewModel, GDSScreenWithTertiaryButtonViewModel {
-    let image: String? = "exclamationmark.circle"
+    let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -30,10 +30,11 @@ enum Screens: String, CaseIterable {
     case gdsResultsView = "Results View"
     case gdsResultsViewModal = "Results View (Modal)"
     case gdsErrorView = "Error View"
+    case gdsErrorViewNoIcon = "Error View (with no icon)"
     case gdsErrorViewWithTertiary = "Error View (with 3 buttons)"
     case gdsInformationView = "Information View"
     case gdsLoadingView = "GDS Loading View"
-
+    
     var isModal: Bool {
         switch self {
         case .gdsModalInfoView,
@@ -61,20 +62,20 @@ enum Screens: String, CaseIterable {
         case .gdsInstructionsWithColouredButton:
             let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockColoredButtonViewModel.primary,
                                                          secondaryButtonViewModel: MockButtonViewModel.secondaryQR) {
-
+                
             }
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
-                                                               screenView: {}, dismissAction: {})
+                                                               screenView: { }, dismissAction: { })
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
                                                                secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
                                                                rightBarButtonTitle: "Close",
-                                                               screenView: {}, dismissAction: {})
+                                                               screenView: { }, dismissAction: { })
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsModalInfoView:
             let view = ModalInfoViewController(viewModel: MockModalInfoViewModel())
@@ -99,10 +100,10 @@ enum Screens: String, CaseIterable {
         case .gdsIconScreen:
             return IconScreenViewController()
         case .gdsQRCodeScanner:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.popViewController(animated: true) } dismissAction: {}
+            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.popViewController(animated: true) } dismissAction: { }
             return ScanningViewController(viewModel: viewModel)
         case .gdsQRCodeScannerModal:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) } dismissAction: {}
+            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.dismiss(animated: true) } dismissAction: { }
             return ScanningViewController(viewModel: viewModel)
         case .gdsResultsView:
             return ResultsViewController(popToRoot: popToRoot, navController: navigationController)
@@ -110,6 +111,8 @@ enum Screens: String, CaseIterable {
             return ResultsViewController(popToRoot: nil, navController: navigationController)
         case .gdsErrorView:
             return GDSErrorViewController(viewModel: MockErrorViewModel())
+        case .gdsErrorViewNoIcon:
+            return GDSErrorViewController(viewModel: MockErrorViewModelNoIcon())
         case .gdsErrorViewWithTertiary:
             return GDSErrorViewController(viewModel: MockErrorViewModelWithTertiary())
         case .gdsInformationView:

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -61,9 +61,8 @@ enum Screens: String, CaseIterable {
             return GDSInstructionsViewController(popToRoot: popToRoot, navController: navigationController)
         case .gdsInstructionsWithColouredButton:
             let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockColoredButtonViewModel.primary,
-                                                         secondaryButtonViewModel: MockButtonViewModel.secondaryQR) {
-                
-            }
+                                                         secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
+                                                         dismissAction: { })
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -2,7 +2,7 @@ import GDSCommon
 import XCTest
 
 final class GDSErrorViewControllerTests: XCTestCase {
-    var viewModel: GDSErrorViewModel!
+    var viewModel: GDSErrorViewModelV2!
     var sut: GDSErrorViewController!
     var primaryButton = false
     var secondaryButton = false
@@ -34,7 +34,7 @@ final class GDSErrorViewControllerTests: XCTestCase {
     }
 }
 
-private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
+private struct TestViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
@@ -105,7 +105,7 @@ private struct TestViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     }
 }
 
-private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
+private struct TestViewModelWithTertiary: GDSErrorViewModelV2, GDSErrorViewModelWithImage, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -35,7 +35,7 @@ final class GDSErrorViewControllerTests: XCTestCase {
 }
 
 private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String? = "exclamationmark.circle"
+    let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel
@@ -70,8 +70,7 @@ private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
     }
 }
 
-private struct TestViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
-    let image: String? = nil
+private struct TestViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel
@@ -107,7 +106,7 @@ private struct TestViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
 }
 
 private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
-    let image: String? = "exclamationmark.circle"
+    let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorViewControllerTests.swift
@@ -35,7 +35,43 @@ final class GDSErrorViewControllerTests: XCTestCase {
 }
 
 private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String = "exclamationmark.circle"
+    let image: String? = "exclamationmark.circle"
+    let title: GDSLocalisedString = "Error screen title"
+    let body: GDSLocalisedString = "Error screen body"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let backButtonIsHidden: Bool = false
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    init(primaryButtonAction: @escaping () -> Void,
+         secondaryButtonAction: @escaping () -> Void,
+         appearAction: @escaping () -> Void,
+         dismissAction: @escaping () -> Void
+    ) {
+        primaryButtonViewModel = MockButtonViewModel(title: "Error primary button title") {
+            primaryButtonAction()
+        }
+        secondaryButtonViewModel = MockButtonViewModel(title: "Error secondary button title") {
+            secondaryButtonAction()
+        }
+        self.appearAction = appearAction
+        self.dismissAction = dismissAction
+    }
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}
+
+private struct TestViewModelNoIcon: GDSErrorViewModel, BaseViewModel {
+    let image: String? = nil
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel
@@ -71,7 +107,7 @@ private struct TestViewModel: GDSErrorViewModel, BaseViewModel {
 }
 
 private struct TestViewModelWithTertiary: GDSErrorViewModel, GDSScreenWithTertiaryButtonViewModel, BaseViewModel {
-    let image: String = "exclamationmark.circle"
+    let image: String? = "exclamationmark.circle"
     let title: GDSLocalisedString = "Error screen title"
     let body: GDSLocalisedString = "Error screen body"
     let primaryButtonViewModel: ButtonViewModel
@@ -137,10 +173,18 @@ extension GDSErrorViewControllerTests {
     }
     
     @MainActor
-    func test_tertiaryButtonContentAndAction() throws {
-        viewModel = nil
-        sut = nil
+    func test_noIcon() throws {
+        viewModel = TestViewModelNoIcon(primaryButtonAction: { },
+                                        secondaryButtonAction: { },
+                                        appearAction: { },
+                                        dismissAction: { })
+        sut = GDSErrorViewController(viewModel: viewModel)
         
+        XCTAssertTrue(try sut.errorImage.isHidden)
+    }
+    
+    @MainActor
+    func test_tertiaryButtonContentAndAction() throws {
         viewModel = TestViewModelWithTertiary {
             self.primaryButton = true
         } secondaryButtonAction: {

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -24,9 +24,13 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     
     @IBOutlet private var errorImage: UIImageView! {
         didSet {
-            let font = UIFont(style: .largeTitle, weight: .light)
-            let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
-            errorImage.image = UIImage(systemName: viewModel.image, withConfiguration: configuration)
+            if let image = viewModel.image {
+                let font = UIFont(style: .largeTitle, weight: .light)
+                let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
+                errorImage.image = UIImage(systemName: image, withConfiguration: configuration)
+            } else {
+                errorImage.isHidden = true
+            }
             errorImage.accessibilityIdentifier = "error-image"
         }
     }
@@ -63,8 +67,6 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
         didSet {
             if let buttonViewModel = viewModel.secondaryButtonViewModel {
                 secondaryButton.setTitle(buttonViewModel.title, for: .normal)
-                secondaryButton.accessibilityIdentifier = "error-secondary-button"
-                
                 if let icon = buttonViewModel.icon {
                     secondaryButton.symbolPosition = icon.symbolPosition
                     secondaryButton.icon = icon.iconName
@@ -72,6 +74,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
             } else {
                 secondaryButton.isHidden = true
             }
+            secondaryButton.accessibilityIdentifier = "error-secondary-button"
         }
     }
     
@@ -83,11 +86,9 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
         didSet {
             if let buttonViewModel = (viewModel as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel {
                 tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
-                
             } else {
                 tertiaryButton.isHidden = true
             }
-            
             tertiaryButton.accessibilityIdentifier = "error-tertiary-button"
         }
     }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -11,7 +11,8 @@ private struct ErrorViewModel: GDSErrorViewModel {
         if let viewModel = viewModelV2 as? GDSErrorViewModelWithImage {
             self.image = viewModel.image
         } else {
-            preconditionFailure("Please upgrade to GDSErrorViewModelV2")
+            assertionFailure("Please upgrade to GDSErrorViewModelV2")
+            self.image = ""
         }
         self.title = viewModelV2.title
         self.body = viewModelV2.body
@@ -30,14 +31,17 @@ private struct ErrorViewModel: GDSErrorViewModel {
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     
-    public var viewModel: GDSErrorViewModel {
-        ErrorViewModel(viewModelV2: viewModelV2)
-    }
+    public private(set) var viewModel: GDSErrorViewModel
     public private(set) var viewModelV2: GDSErrorViewModelV2
     
-    public init(viewModelV2: GDSErrorViewModelV2) {
-        self.viewModelV2 = viewModelV2
-        super.init(viewModel: viewModelV2 as? BaseViewModel, nibName: "GDSError", bundle: .module)
+    public init(viewModel: GDSErrorViewModelV2) {
+        if let viewModel = viewModel as? GDSErrorViewModel {
+            self.viewModel = viewModel
+        } else {
+            self.viewModel = ErrorViewModel(viewModelV2: viewModel)
+        }
+        self.viewModelV2 = viewModel
+        super.init(viewModel: viewModel as? BaseViewModel, nibName: "GDSError", bundle: .module)
     }
     
     @available(*, unavailable, renamed: "init(coordinator:)")
@@ -47,7 +51,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     
     @IBOutlet private var errorImage: UIImageView! {
         didSet {
-            if viewModel is GDSErrorViewModelV2 {
+            if let viewModel = viewModelV2 as? GDSErrorViewModelWithImage {
                 let font = UIFont(style: .largeTitle, weight: .light)
                 let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
                 errorImage.image = UIImage(systemName: viewModel.image, withConfiguration: configuration)

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -1,5 +1,25 @@
 import UIKit
 
+private struct ErrorViewModel: GDSErrorViewModel {
+    let image: String
+    let title: GDSLocalisedString
+    let body: GDSLocalisedString
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    
+    init(viewModelV2: GDSErrorViewModelV2) {
+        if let viewModel = viewModelV2 as? GDSErrorViewModelWithImage {
+            self.image = viewModel.image
+        } else {
+            preconditionFailure("Please upgrade to GDSErrorViewModelV2")
+        }
+        self.title = viewModelV2.title
+        self.body = viewModelV2.body
+        self.primaryButtonViewModel = viewModelV2.primaryButtonViewModel
+        self.secondaryButtonViewModel = viewModelV2.secondaryButtonViewModel
+    }
+}
+
 /// View controller for `GDSError` screen
 ///     - `errorImage` (type: `String`)
 ///     - `titleLabel` (type: `UILabel`)
@@ -10,11 +30,14 @@ import UIKit
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     
-    public private(set) var viewModel: GDSErrorViewModel
+    public var viewModel: GDSErrorViewModel {
+        ErrorViewModel(viewModelV2: viewModelV2)
+    }
+    public private(set) var viewModelV2: GDSErrorViewModelV2
     
-    public init(viewModel: GDSErrorViewModel) {
-        self.viewModel = viewModel
-        super.init(viewModel: viewModel as? BaseViewModel, nibName: "GDSError", bundle: .module)
+    public init(viewModelV2: GDSErrorViewModelV2) {
+        self.viewModelV2 = viewModelV2
+        super.init(viewModel: viewModelV2 as? BaseViewModel, nibName: "GDSError", bundle: .module)
     }
     
     @available(*, unavailable, renamed: "init(coordinator:)")
@@ -24,10 +47,10 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     
     @IBOutlet private var errorImage: UIImageView! {
         didSet {
-            if let image = viewModel.image {
+            if viewModel is GDSErrorViewModelV2 {
                 let font = UIFont(style: .largeTitle, weight: .light)
                 let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
-                errorImage.image = UIImage(systemName: image, withConfiguration: configuration)
+                errorImage.image = UIImage(systemName: viewModel.image, withConfiguration: configuration)
             } else {
                 errorImage.isHidden = true
             }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-private struct ErrorViewModel: GDSErrorViewModel {
+private struct ErrorViewModelInitialiser: GDSErrorViewModel {
     let image: String
     let title: GDSLocalisedString
     let body: GDSLocalisedString
@@ -37,7 +37,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
         if let viewModel = viewModel as? GDSErrorViewModel {
             self.viewModel = viewModel
         } else {
-            self.viewModel = ErrorViewModel(viewModelV2: viewModel)
+            self.viewModel = ErrorViewModelInitialiser(viewModelV2: viewModel)
         }
         self.viewModelV2 = viewModel
         super.init(viewModel: viewModel as? BaseViewModel, nibName: "GDSError", bundle: .module)

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -110,7 +110,7 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     
     @IBOutlet private var tertiaryButton: SecondaryButton! {
         didSet {
-            if let buttonViewModel = (viewModel as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel {
+            if let buttonViewModel = (viewModelV2 as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel {
                 tertiaryButton.setTitle(buttonViewModel.title, for: .normal)
             } else {
                 tertiaryButton.isHidden = true
@@ -120,6 +120,6 @@ public final class GDSErrorViewController: BaseViewController, TitledViewControl
     }
     
     @IBAction private func tertiaryButtonAction(_ sender: Any) {
-        (viewModel as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
+        (viewModelV2 as? GDSScreenWithTertiaryButtonViewModel)?.tertiaryButtonViewModel.action()
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -11,7 +11,6 @@ private struct ErrorViewModel: GDSErrorViewModel {
         if let viewModel = viewModelV2 as? GDSErrorViewModelWithImage {
             self.image = viewModel.image
         } else {
-            assertionFailure("Please upgrade to GDSErrorViewModelV2")
             self.image = ""
         }
         self.title = viewModelV2.title

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -1,17 +1,42 @@
 import UIKit
 
 /// Protocol for the view model required to initilise ``ErrorViewModel``
+//@MainActor
+//public protocol GDSErrorViewModel {
+//    var image: String { get }
+//    var title: GDSLocalisedString { get }
+//    var body: GDSLocalisedString { get }
+//    var primaryButtonViewModel: ButtonViewModel { get }
+//    var secondaryButtonViewModel: ButtonViewModel? { get }
+//}
+
+/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
 @MainActor
-public protocol GDSErrorViewModel {
-    var image: String? { get }
+public protocol GDSScreenWithTertiaryButtonViewModel {
+    var tertiaryButtonViewModel: ButtonViewModel { get }
+}
+
+//@MainActor
+//public protocol GDSErrorViewModelV2 {
+//    var image: String? { get }
+//    var title: GDSLocalisedString { get }
+//    var body: GDSLocalisedString { get }
+//    var primaryButtonViewModel: ButtonViewModel { get }
+//    var secondaryButtonViewModel: ButtonViewModel? { get }
+//}
+
+@available(*, deprecated, renamed: "GDSErrorViewModelV2", message: "Should also conform to GDSErrorViewModelWithImage if image is required")
+public typealias GDSErrorViewModel = GDSErrorViewModelV2 & GDSErrorViewModelWithImage
+
+@MainActor
+public protocol GDSErrorViewModelV2 {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
 
-/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
 @MainActor
-public protocol GDSScreenWithTertiaryButtonViewModel {
-    var tertiaryButtonViewModel: ButtonViewModel { get }
+public protocol GDSErrorViewModelWithImage {
+    var image: String { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Protocol for the view model required to initilise ``ErrorViewModel``
 @MainActor
 public protocol GDSErrorViewModel {
-    var image: String { get }
+    var image: String? { get }
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var primaryButtonViewModel: ButtonViewModel { get }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -1,9 +1,10 @@
 import UIKit
 
-/// Protocol for the view model required to initilise ``ErrorViewModel``
+/// Deprecated alias to allow initialisation of ``GDSErrorViewController`` combining the below two protocols
 @available(*, deprecated, renamed: "GDSErrorViewModelV2", message: "Should also conform to GDSErrorViewModelWithImage if image is required")
 public typealias GDSErrorViewModel = GDSErrorViewModelV2 & GDSErrorViewModelWithImage
 
+/// Protocol for the view model required to initilise ``GDSErrorViewController``
 @MainActor
 public protocol GDSErrorViewModelV2 {
     var title: GDSLocalisedString { get }
@@ -12,12 +13,13 @@ public protocol GDSErrorViewModelV2 {
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
 
+/// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a image icon
 @MainActor
 public protocol GDSErrorViewModelWithImage {
     var image: String { get }
 }
 
-/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
+/// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a tertiary button
 @MainActor
 public protocol GDSScreenWithTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -22,4 +22,3 @@ public protocol GDSErrorViewModelWithImage {
 public protocol GDSScreenWithTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }
 }
-

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -1,30 +1,6 @@
 import UIKit
 
 /// Protocol for the view model required to initilise ``ErrorViewModel``
-//@MainActor
-//public protocol GDSErrorViewModel {
-//    var image: String { get }
-//    var title: GDSLocalisedString { get }
-//    var body: GDSLocalisedString { get }
-//    var primaryButtonViewModel: ButtonViewModel { get }
-//    var secondaryButtonViewModel: ButtonViewModel? { get }
-//}
-
-/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
-@MainActor
-public protocol GDSScreenWithTertiaryButtonViewModel {
-    var tertiaryButtonViewModel: ButtonViewModel { get }
-}
-
-//@MainActor
-//public protocol GDSErrorViewModelV2 {
-//    var image: String? { get }
-//    var title: GDSLocalisedString { get }
-//    var body: GDSLocalisedString { get }
-//    var primaryButtonViewModel: ButtonViewModel { get }
-//    var secondaryButtonViewModel: ButtonViewModel? { get }
-//}
-
 @available(*, deprecated, renamed: "GDSErrorViewModelV2", message: "Should also conform to GDSErrorViewModelWithImage if image is required")
 public typealias GDSErrorViewModel = GDSErrorViewModelV2 & GDSErrorViewModelWithImage
 
@@ -40,3 +16,10 @@ public protocol GDSErrorViewModelV2 {
 public protocol GDSErrorViewModelWithImage {
     var image: String { get }
 }
+
+/// Conform view models that inherit from ``ErrorViewModel`` to this protocol to set a tertiary button
+@MainActor
+public protocol GDSScreenWithTertiaryButtonViewModel {
+    var tertiaryButtonViewModel: ButtonViewModel { get }
+}
+

--- a/Sources/GDSCommon/Patterns/README.md
+++ b/Sources/GDSCommon/Patterns/README.md
@@ -231,7 +231,6 @@ This screen includes an title, subtitle and button. These views a situated withi
 The content on the screen is set from the `viewModel`, which must conform to the `OptionViewModel` protocol.
 
 ## GDSError
-
 This screen is typically used as an error screen, consisting of an alert icon, a title, body and the option of one, two or three buttons.
 A `UIStackView` holds the `errorImageView` and encases a second `UIStackView` which holds the `errorTitle` and `errorBody`. These views are placed within a `ScrollView`.
 The `primaryButton`, `secondaryButton` and `tertiaryButton` are placed in a `UIStackView`, below the `ScrollView`.
@@ -253,7 +252,7 @@ If the viewModel conforms to BaseViewModel:
 
 ```swift
 struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String = "exclamationmark.circle"
+    let image: String? = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
     let primaryButtonViewModel: ButtonViewModel 

--- a/Sources/GDSCommon/Patterns/README.md
+++ b/Sources/GDSCommon/Patterns/README.md
@@ -1,7 +1,6 @@
 # Patterns
 
 ## BaseViewController
-
 ``BaseViewController`` inherits from `UIViewController`. ``BaseViewController`` includes the repetitive code that all screens should have to avoid repetition and reduce risk of missing important functionality and to make it easier to amend, or fix defects if they arise.
 
 Screen view controllers should generally inherit from ``BaseViewController`` instead of `UIViewController` unless the functionality of the screen needs to be intentionally different from standard screens.
@@ -48,6 +47,7 @@ struct ConcreteModalInfoViewModel: ExampleInfoViewModel, BaseViewModel {
 }
 ```
 
+
 ## GDSInstructions
 This screen includes the following views:
 - `titleLabel` (type: `UILabel`)
@@ -80,7 +80,6 @@ The content on the screen is set from the `viewModel`, which must conform to the
 
 
 ## PopoverTableViewController
-
 ``PopoverTableViewController`` inherits from `UIViewController`. This allows showing a list, as a popover giving the user multiple options from one button. To use this the view controller will need to conform to `UIPopoverPresentationControllerDelegate`.
 
 This screen includes the following views:
@@ -119,7 +118,6 @@ The content on the screen is set from the `viewModel`, which must conform to the
 
 
 ## ListOptions
-
 This screen includes the following views:
 - `titleLabel` (type: `UILabel`)
 - `bodyLabel` (type: `UILabel`?)
@@ -161,7 +159,7 @@ The `primaryButton` and `secondaryButton` are `UIButton`s and placed within a `U
 The configuration for these views are set from the `viewModel`, which must conform to the `PageWithPrimaryButtonViewModel` and `PageWithSecondaryButtonViewModel` protocols respectively. If the `viewmodel` does not conform to these protocols and provide these properties, the buttons will be hidden.
 
 
-### GDSLoadingScreen
+## GDSLoadingScreen
  This screen includes the following views:
  - `loadingLabel` (type: `UILabel`)
 
@@ -230,8 +228,9 @@ This screen includes the following views:
 This screen includes an title, subtitle and button. These views a situated within a `UIStackView` which has margins set to align the subviews within it. This view is typically added as a subview to the `IconScreen` through the `IconScreen`s view model `childViews` property.
 The content on the screen is set from the `viewModel`, which must conform to the `OptionViewModel` protocol.
 
+
 ## GDSError
-This screen is typically used as an error screen, consisting of an alert icon, a title, body and the option of one, two or three buttons.
+This screen is typically used as an error screen, consisting of an optional alert icon, a title, body and the option of one, two or three buttons.
 A `UIStackView` holds the `errorImageView` and encases a second `UIStackView` which holds the `errorTitle` and `errorBody`. These views are placed within a `ScrollView`.
 The `primaryButton`, `secondaryButton` and `tertiaryButton` are placed in a `UIStackView`, below the `ScrollView`.
 
@@ -251,7 +250,7 @@ If the viewModel conforms to BaseViewModel:
 ### Example:
 
 ```swift
-struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String? = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
@@ -272,8 +271,8 @@ struct MockErrorViewModel: GDSErrorViewModel, BaseViewModel {
 }
 ```
 
-## GDSInformation
 
+## GDSInformation
 This screen is designed to present information to users, consisting of an image, title, (optional) body, (optional) footnote, primary button and an (optional) secondary button.
 
 As part of the confirguation of the image, it has the following customisation: 
@@ -322,6 +321,7 @@ struct MockGDSInformationViewModel: GDSInformationViewModel, BaseViewModel {
     func didDismiss() {}
 }
 ```
+
 
 # Accessibility
 


### PR DESCRIPTION
# DCMAW-9589: iOS | Update designs for 'You've been signed out' re-auth page

Previously every GDSError screen had an icon image as part of the screen. This PR implements non-breaking changes for the package to deprecate the `GDSErrorViewModel` and allowing the use of two protocols; `GDSErrorViewModelV2` & `GDSErrorViewModelWithImage`

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
