### PR TITLE
feat: adds optional child view to GDSInformationViewController

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -65,10 +65,18 @@ extension GDSListOptionsViewController {
     }
 }
 
+//extension GDSInformationViewController {
+//    convenience init() {
+//        let viewModel = MockGDSInformationViewModel()
+//        
+//        self.init(viewModel: viewModel)
+//    }
+//}
+
 extension GDSInformationViewController {
     convenience init() {
-        let viewModel = MockGDSInformationViewModel()
-        
+        let viewModel = MockGDSInformationViewModelWithChildView()
+
         self.init(viewModel: viewModel)
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -65,14 +65,6 @@ extension GDSListOptionsViewController {
     }
 }
 
-//extension GDSInformationViewController {
-//    convenience init() {
-//        let viewModel = MockGDSInformationViewModel()
-//        
-//        self.init(viewModel: viewModel)
-//    }
-//}
-
 extension GDSInformationViewController {
     convenience init() {
         let viewModel = MockGDSInformationViewModelWithChildView()

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInformationViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInformationViewModel.swift
@@ -18,3 +18,42 @@ struct MockGDSInformationViewModel: GDSInformationViewModel, BaseViewModel {
     
     func didDismiss() {}
 }
+
+struct MockGDSInformationViewModelWithChildView: GDSInformationViewModel, GDSInformationViewModelWithChildView, BaseViewModel {
+    let image: String = "lock"
+    let imageWeight: UIFont.Weight? = nil
+    let imageColour: UIColor? = nil
+    let imageHeightConstraint: CGFloat? = nil
+    let title: GDSLocalisedString = "This is an Information View title"
+    let body: GDSLocalisedString? = "This is an (optional) Information View body."
+    let footnote: GDSLocalisedString? = "This is an (optional) Information View footnote where additional information for the buttons can be detailed."
+    let primaryButtonViewModel: ButtonViewModel = MockButtonViewModel.primary
+    let secondaryButtonViewModel: ButtonViewModel? = MockButtonViewModel.secondary
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+
+    func didAppear() {}
+
+    func didDismiss() {}
+
+    var childView: UIView? {
+        createChildView()
+    }
+
+    private func createChildView() -> UIView {
+        let bulletView = BulletView(viewModel: MockBulletViewModel(title: nil))
+        let body = UILabel()
+        body.text = "Some text can go here:"
+        body.adjustsFontForContentSizeCategory = true
+        body.numberOfLines = 0
+        let body2 = UILabel()
+        body2.text = GDSLocalisedString(stringLiteral: "More text can follow below, too").value
+        body2.adjustsFontForContentSizeCategory = true
+        body2.numberOfLines = 0
+        let stackView = UIStackView(arrangedSubviews: [body, bulletView, body2])
+        stackView.axis = .vertical
+        stackView.alignment = .top
+        stackView.spacing = 12
+        return stackView
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInformationViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInformationViewModel.swift
@@ -43,11 +43,11 @@ struct MockGDSInformationViewModelWithChildView: GDSInformationViewModel, GDSInf
     private func createChildView() -> UIView {
         let bulletView = BulletView(viewModel: MockBulletViewModel(title: nil))
         let body = UILabel()
-        body.text = "Some text can go here:"
+        body.text = "Some (optional) text can go here and below (also optional):"
         body.adjustsFontForContentSizeCategory = true
         body.numberOfLines = 0
         let body2 = UILabel()
-        body2.text = GDSLocalisedString(stringLiteral: "More text can follow below, too").value
+        body2.text = GDSLocalisedString(stringLiteral: "More (optional) text can follow, too").value
         body2.adjustsFontForContentSizeCategory = true
         body2.numberOfLines = 0
         let stackView = UIStackView(arrangedSubviews: [body, bulletView, body2])

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInformationViewControllerTests.swift
@@ -122,6 +122,22 @@ extension GDSInformationViewControllerTests {
         _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
         XCTAssertTrue(viewDidDismiss)
     }
+
+    func test_optionalChildView() throws {
+        let childView = try XCTUnwrap(sut.childView)
+        let childViewBody1: UILabel = try XCTUnwrap(childView[child: "body1-text"])
+        let childViewBody2: UILabel = try XCTUnwrap(childView[child: "body2-text"])
+        let bulletTitle: UILabel = try XCTUnwrap(childView[child: "bullet-title"])
+        let stack: UIStackView = try XCTUnwrap(childView[child: "bullet-stack"])
+        let bulletLabels: [UILabel] = try XCTUnwrap(stack.arrangedSubviews as? [UILabel])
+        
+        XCTAssertEqual(childViewBody1.text, "Some text")
+        XCTAssertEqual(bulletTitle.text, "bullet title")
+        XCTAssertEqual(bulletLabels[0].text, "\t●\tbullet 1")
+        XCTAssertEqual(bulletLabels[1].text, "\t●\tbullet 2")
+        XCTAssertEqual(bulletLabels[2].text, "\t●\tbullet 3")
+        XCTAssertEqual(childViewBody2.text, "More text")
+    }
 }
 
 struct MockButtonIconViewModel: ButtonIconViewModel {
@@ -163,6 +179,12 @@ extension GDSInformationViewController {
     var secondaryButton: SecondaryButton {
         get throws {
             try XCTUnwrap(view[child: "information-secondary-button"])
+        }
+    }
+
+    var childView: UIStackView {
+        get throws {
+            try XCTUnwrap(view[child: "information-optional-stack-view"])
         }
     }
 }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInformationViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInformationViewModel.swift
@@ -1,13 +1,16 @@
 import GDSCommon
 import UIKit
 
-struct MockGDSInformationViewModel: GDSInformationViewModel, BaseViewModel {
+struct MockGDSInformationViewModel: GDSInformationViewModel, GDSInformationViewModelWithChildView, BaseViewModel {
     let image: String = "lock"
     let imageWeight: UIFont.Weight? = .semibold
     let imageColour: UIColor? = .gdsPrimary
     let imageHeightConstraint: CGFloat? = 55
     let title: GDSLocalisedString = "Information screen title"
     let body: GDSLocalisedString? = "Information screen body"
+    var childView: UIView? {
+        createChildView()
+    }
     let footnote: GDSLocalisedString? = "Information screen footnote"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
@@ -33,5 +36,32 @@ struct MockGDSInformationViewModel: GDSInformationViewModel, BaseViewModel {
     
     func didDismiss() {
         dismissAction()
+    }
+
+    private func createChildView() -> UIView {
+        let bulletView = createMockBulletView()
+        let body = UILabel()
+        body.text = "Some text"
+        body.accessibilityIdentifier = "body1-text"
+        body.adjustsFontForContentSizeCategory = true
+        body.numberOfLines = 0
+        let body2 = UILabel()
+        body2.text = GDSLocalisedString(stringLiteral: "More text").value
+        body2.accessibilityIdentifier = "body2-text"
+        body2.adjustsFontForContentSizeCategory = true
+        body2.numberOfLines = 0
+        let stackView = UIStackView(arrangedSubviews: [body, bulletView, body2])
+        stackView.axis = .vertical
+        stackView.alignment = .top
+        stackView.spacing = 12
+        return stackView
+    }
+
+    private func createMockBulletView() -> BulletView {
+        let bulletView = BulletView(title: "bullet title",
+                                text: ["bullet 1",
+                                       "bullet 2",
+                                       "bullet 3"])
+        return bulletView
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformation.xib
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformation.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -17,6 +17,7 @@
                 <outlet property="informationImage" destination="vXP-wQ-k57" id="Nxf-ym-LI1"/>
                 <outlet property="primaryButton" destination="a2l-9h-5cw" id="AAv-Xb-ZDH"/>
                 <outlet property="secondaryButton" destination="5JG-e4-Yqj" id="2RO-Qb-cCX"/>
+                <outlet property="stackView" destination="u2P-6P-arU" id="XUT-af-SU9"/>
                 <outlet property="titleLabel" destination="tXa-cd-Nuw" id="ea9-Gw-C2m"/>
                 <outlet property="view" destination="KNE-jX-vud" id="MO0-sG-eTd"/>
             </connections>

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewController.swift
@@ -118,8 +118,8 @@ public final class GDSInformationViewController: BaseViewController, TitledViewC
         didSet {
             if let childView = (viewModel as? GDSInformationViewModelWithChildView)?.childView {
                 stackView.addArrangedSubview(childView)
+                stackView.accessibilityIdentifier = "information-optional-stack-view"
             }
-            stackView.accessibilityIdentifier = "information-optional-stack-view"
         }
     }
 

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewController.swift
@@ -11,6 +11,7 @@ public final class GDSInformationViewController: BaseViewController, TitledViewC
     public override var nibName: String? { "GDSInformation" }
     
     public private(set) var viewModel: GDSInformationViewModel
+
     private let defaultImageHeight: CGFloat = 55
     private let imagePaddingCompensation: CGFloat = 11
     
@@ -110,7 +111,18 @@ public final class GDSInformationViewController: BaseViewController, TitledViewC
             }
         }
     }
-    
+
+    /// Stack View: `UIStackView`. Any `UIView` which is on the `GDSInformationViewModelWithChildView` view model's `childView` property.
+    /// This will be added to the `stackView` below the existing `bodyLabel`
+    @IBOutlet private var stackView: UIStackView! {
+        didSet {
+            if let childView = (viewModel as? GDSInformationViewModelWithChildView)?.childView {
+                stackView.addArrangedSubview(childView)
+            }
+            stackView.accessibilityIdentifier = "information-optional-stack-view"
+        }
+    }
+
     @IBAction private func secondaryButtonAction(_ sender: Any) {
         viewModel.secondaryButtonViewModel?.action()
     }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModel.swift
@@ -32,3 +32,8 @@ public protocol GDSInformationViewModel {
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
+
+@MainActor
+public protocol GDSInformationViewModelWithChildView {
+    var childView: UIView? { get }
+}


### PR DESCRIPTION
# DCMAW-10141 - Updating existing GDSInformationViewController in GDSCommon

An optional child view has been added to GDSInformationViewController in order for upcoming design requirements to be met. 

Updated screen:
<img src="https://github.com/user-attachments/assets/3ad28a8c-165f-417a-839b-8042cd1336e5" height="600" width="300"></img>

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
