### PR TITLE
fix: properly setting button colour

### DIFF
--- a/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
+++ b/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
@@ -139,13 +139,13 @@ public final class GDSContentTileView: NibView {
         secondaryButton.accessibilityIdentifier = "content-secondary-button"
         
         if let viewModel = viewModel as? GDSContentTileViewModelWithSecondaryButton {
-            secondaryButton.titleLabel?.textColor = .gdsGreen
             if let icon = viewModel.secondaryButtonViewModel.icon {
                 secondaryButton.symbolPosition = icon.symbolPosition
                 secondaryButton.icon = icon.iconName
             }
             secondaryButton.contentHorizontalAlignment = .left
             secondaryButton.setTitle(viewModel.secondaryButtonViewModel.title.value, for: .normal)
+            secondaryButton.setTitleColor(.gdsGreen, for: .normal)
             secondaryButton.addTarget(self, action: #selector(secondaryButtonTapped), for: .touchUpInside)
             secondaryButton.isUserInteractionEnabled = true
             return secondaryButton

--- a/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.xib
+++ b/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -35,21 +36,21 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VIe-7s-SPk">
                             <rect key="frame" x="0.0" y="54" width="393" height="61"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xrQ-OE-IN9">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xrQ-OE-IN9">
                                     <rect key="frame" x="0.0" y="0.0" width="393" height="20.333333333333332"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uoK-UE-05d">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uoK-UE-05d">
                                     <rect key="frame" x="0.0" y="20.333333333333329" width="393" height="20.333333333333329"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sEr-UI-8SY">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sEr-UI-8SY">
                                     <rect key="frame" x="0.0" y="40.666666666666671" width="393" height="20.333333333333329"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
@@ -103,7 +103,7 @@ extension GDSContentTileViewTests {
     
     func test_secondaryButton() throws {
         XCTAssertEqual(try sut.secondaryButton.titleLabel?.text, viewModel.secondaryButtonViewModel.title.value)
-        XCTAssertEqual(try sut.secondaryButton.titleLabel?.tintColor, UIColor.gdsGreen)
+        XCTAssertEqual(try sut.secondaryButton.currentTitleColor, UIColor.gdsGreen)
         XCTAssertNil(try sut.secondaryButton.icon)
         
         XCTAssertFalse(didTapSecondaryButton)


### PR DESCRIPTION
# fix: properly setting button colour

When conforming to the content tile, it was noticed that the secondary button appeared white. This is likely to be because the colour was not set correctly here. This PR aims to set the colour of the secondary button in the correct way.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
