### PR TITLE
feat: fix GDSCentreAlignedScreen image

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -164,6 +164,20 @@ extension GDSCentreAlignedScreenTests {
         XCTAssertEqual(bulletLabels[2].text, "\t●\tbullet 3")
         XCTAssertEqual(childViewBody.text, "More text")
     }
+    
+    func test_imageIsNotHidden() throws {
+        XCTAssertFalse(try sut.image.isHidden)
+    }
+    
+    func test_imageIsHidden() throws {
+        viewModel = MockGDSCentreAlignedViewModelNoImage(primaryButtonViewModel: primaryButtonViewModel,
+                                                         secondaryButtonViewModel: secondaryButtonViewModel,
+                                                         appearAction: {},
+                                                         dismissAction: {})
+        
+        sut = GDSCentreAlignedScreen(viewModel: viewModel)
+        XCTAssertTrue(try sut.image.isHidden)
+    }
 }
 
 // MARK: - GDSInformationVieWModelV2 Tests

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSCentreAlignedViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSCentreAlignedViewModel.swift
@@ -69,6 +69,41 @@ struct MockGDSCentreAlignedViewModel: GDSCentreAlignedViewModel,
     }
 }
 
+struct MockGDSCentreAlignedViewModelNoImage: GDSCentreAlignedViewModel,
+                                             GDSCentreAlignedViewModelWithFootnote,
+                                             GDSCentreAlignedViewModelWithPrimaryButton,
+                                             GDSCentreAlignedViewModelWithSecondaryButton,
+                                             BaseViewModel {
+    let title: GDSLocalisedString = "Centre aligned screen title"
+    let body: GDSLocalisedString? = "Centre aligned screen body"
+    let footnote: GDSLocalisedString = "Centre aligned screen footnote"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let backButtonIsHidden: Bool = false
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    init(primaryButtonViewModel: ButtonViewModel,
+         secondaryButtonViewModel: ButtonViewModel,
+         appearAction: @escaping () -> Void,
+         dismissAction: @escaping () -> Void) {
+        self.primaryButtonViewModel = primaryButtonViewModel
+        self.secondaryButtonViewModel = secondaryButtonViewModel
+        self.appearAction = appearAction
+        self.dismissAction = dismissAction
+    }
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}
+
 struct MockGDSInformationViewModelV2: GDSInformationViewModelV2,
                                       GDSInformationViewModelWithFootnote,
                                       GDSInformationViewModelWithOptionalPrimaryButton,

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -107,6 +107,8 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
                 NSLayoutConstraint.activate([
                     image.heightAnchor.constraint(greaterThanOrEqualToConstant: heightConstraint)
                 ])
+            } else {
+                image.isHidden = true
             }
         }
     }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -91,7 +91,6 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
                 
                 image.image = UIImage(systemName: viewModel.image, withConfiguration: configuration)
                 image.tintColor = viewModel.imageColour ?? .gdsPrimary
-                image.accessibilityIdentifier = "centre-aligned-screen-image"
                 
                 /// Minimum height constraint for the image view
                 var heightConstraint: CGFloat {
@@ -110,6 +109,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             } else {
                 image.isHidden = true
             }
+            image.accessibilityIdentifier = "centre-aligned-screen-image"
         }
     }
     

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModelV2.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSInformationViewModelV2.swift
@@ -1,26 +1,26 @@
 import UIKit
 
 @available(*, deprecated,
-            renamed: "CentreAlignedViewModel",
-            message: "Should conform to CentreAlignedViewModel and CentreAlignedViewModelWithImage")
+            renamed: "GDSCentreAlignedViewModel",
+            message: "Should conform to GDSCentreAlignedViewModel and GDSCentreAlignedViewModelWithImage")
 public typealias GDSInformationViewModelV2 = GDSCentreAlignedViewModel & GDSCentreAlignedViewModelWithImage
 
 @available(*, deprecated,
-            renamed: "CentreAlignedViewModelWithFootnote",
-            message: "Should conform to CentreAlignedViewModelWithFootnote instead")
+            renamed: "GDSCentreAlignedViewModelWithFootnote",
+            message: "Should conform to GDSCentreAlignedViewModelWithFootnote instead")
 public typealias GDSInformationViewModelWithFootnote = GDSCentreAlignedViewModelWithFootnote
 
 @available(*, deprecated,
-            renamed: "CentreAlignedViewModelWithPrimaryButton",
-            message: "Should conform to CentreAlignedViewModelWithPrimaryButton instead")
+            renamed: "GDSCentreAlignedViewModelWithPrimaryButton",
+            message: "Should conform to GDSCentreAlignedViewModelWithPrimaryButton instead")
 public typealias GDSInformationViewModelPrimaryButton = GDSCentreAlignedViewModelWithPrimaryButton
 
 @available(*, deprecated,
-            renamed: "CentreAlignedViewModelWithSecondaryButton",
-            message: "Should conform to CentreAlignedViewModelWithSecondaryButton instead")
+            renamed: "GDSCentreAlignedViewModelWithSecondaryButton",
+            message: "Should conform to GDSCentreAlignedViewModelWithSecondaryButton instead")
 public typealias GDSInformationViewModelWithSecondaryButton = GDSCentreAlignedViewModelWithSecondaryButton
 
 @available(*, deprecated,
-            renamed: "CentreAlignedViewModelWithChildView",
-            message: "Should conform to CentreAlignedViewModelWithChildView instead")
+            renamed: "GDSCentreAlignedViewModelWithChildView",
+            message: "Should conform to GDSCentreAlignedViewModelWithChildView instead")
 public typealias GDSInformationViewModelWithChildView = GDSCentreAlignedViewModelWithChildView


### PR DESCRIPTION
# DCMAW:10541 Update Modal Content

Added in an else block to hide the image if the viewModel does not conform to GDSCentreAlignedViewModelWithImage and added in tests for image being displayed and hidden. 

Updated the deprecated warnings to include GDS prefix.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
