### PR TITLE
refactor: creates ImageWithLabel protocol, updates InstructionsWithIm…

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
@@ -1,15 +1,13 @@
 import GDSCommon
 import UIKit
 
-struct MockImageWithLabel: ImageWithLabel {
-    let image: UIImage = UIImage(named: "licence")!
-    let imageLabel: GDSLocalisedString = .init(stringLiteral: "An example licence")
-}
-
-class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseViewModel {
+class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel,
+                                          InstructionsWithImageWithAltTextViewModel,
+                                          BaseViewModel {
     var title: GDSLocalisedString
     var body: NSAttributedString
-    var imageWithLabel: ImageWithLabel = MockImageWithLabel()
+    var image: UIImage
+    var imageAltText: GDSLocalisedString
     var warningButtonViewModel: ButtonViewModel?
     var primaryButtonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
@@ -21,7 +19,8 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseVi
 
     init(title: GDSLocalisedString = "This is the Instructions with image view",
          body: NSAttributedString = NSAttributedString("We can use this body to provide details or context as to what we want the users to do"),
-         imageWithLabel: MockImageWithLabel,
+         image: UIImage = UIImage(named: "licence")!,
+         imageAltText: GDSLocalisedString = "An example licence",
          warningButtonViewModel: ButtonViewModel? = nil,
          primaryButtonViewModel: ButtonViewModel,
          secondaryButtonViewModel: ButtonViewModel? = nil,
@@ -30,7 +29,8 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseVi
          dismissAction: @escaping () -> Void) {
         self.title = title
         self.body = body
-        self.imageWithLabel = imageWithLabel
+        self.image = image
+        self.imageAltText = imageAltText
         self.warningButtonViewModel = warningButtonViewModel
         self.primaryButtonViewModel = primaryButtonViewModel
         self.secondaryButtonViewModel = secondaryButtonViewModel

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
@@ -1,10 +1,15 @@
 import GDSCommon
 import UIKit
 
+struct MockImageWithLabel: ImageWithLabel {
+    let image: UIImage = UIImage(named: "licence")!
+    let imageLabel: GDSLocalisedString = .init(stringLiteral: "An example licence")
+}
+
 class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseViewModel {
     var title: GDSLocalisedString
     var body: NSAttributedString
-    var image: UIImage
+    var imageWithLabel: ImageWithLabel = MockImageWithLabel()
     var warningButtonViewModel: ButtonViewModel?
     var primaryButtonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
@@ -13,10 +18,10 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseVi
 
     let screenView: () -> Void
     let dismissAction: () -> Void
-    
+
     init(title: GDSLocalisedString = "This is the Instructions with image view",
          body: NSAttributedString = NSAttributedString("We can use this body to provide details or context as to what we want the users to do"),
-         image: UIImage = UIImage(named: "licence")!,
+         imageWithLabel: MockImageWithLabel,
          warningButtonViewModel: ButtonViewModel? = nil,
          primaryButtonViewModel: ButtonViewModel,
          secondaryButtonViewModel: ButtonViewModel? = nil,
@@ -25,7 +30,7 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel, BaseVi
          dismissAction: @escaping () -> Void) {
         self.title = title
         self.body = body
-        self.image = image
+        self.imageWithLabel = imageWithLabel
         self.warningButtonViewModel = warningButtonViewModel
         self.primaryButtonViewModel = primaryButtonViewModel
         self.secondaryButtonViewModel = secondaryButtonViewModel

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -67,14 +67,14 @@ enum Screens: String, CaseIterable {
                                                          dismissAction: { })
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
-            let viewModel = MockInstructionsWithImageViewModel(imageWithLabel: MockImageWithLabel(),
-                                                               warningButtonViewModel: MockButtonViewModel.primary,
+            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel:
+                                                                MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
                                                                screenView: { }, dismissAction: { })
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
-            let viewModel = MockInstructionsWithImageViewModel(imageWithLabel: MockImageWithLabel(),
-                                                               warningButtonViewModel: MockButtonViewModel.primary,
+            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel:
+                                                                MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
                                                                secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
                                                                rightBarButtonTitle: "Close",

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -67,12 +67,14 @@ enum Screens: String, CaseIterable {
                                                          dismissAction: { })
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
+            let viewModel = MockInstructionsWithImageViewModel(imageWithLabel: MockImageWithLabel(),
+                                                               warningButtonViewModel: MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
                                                                screenView: { }, dismissAction: { })
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
+            let viewModel = MockInstructionsWithImageViewModel(imageWithLabel: MockImageWithLabel(),
+                                                               warningButtonViewModel: MockButtonViewModel.primary,
                                                                primaryButtonViewModel: MockButtonViewModel.primary,
                                                                secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
                                                                rightBarButtonTitle: "Close",

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -20,6 +20,7 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
         super.setUp()
         
         viewModel = MockInstructionsWithImageViewModel(
+            imageWithLabel: MockImageWithLabel(),
             warningButtonViewModel: MockButtonViewModel(
                 title: "Warning Button",
                 shouldLoadOnTap: false,
@@ -175,7 +176,7 @@ extension InstructionsWithImageViewController {
     
     var imageView: UIImageView {
         get throws {
-            try XCTUnwrap(view[child: "imageView"])
+            try XCTUnwrap(view[child: "An example licence"])
         }
     }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -20,7 +20,6 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
         super.setUp()
         
         viewModel = MockInstructionsWithImageViewModel(
-            imageWithLabel: MockImageWithLabel(),
             warningButtonViewModel: MockButtonViewModel(
                 title: "Warning Button",
                 shouldLoadOnTap: false,
@@ -176,7 +175,7 @@ extension InstructionsWithImageViewController {
     
     var imageView: UIImageView {
         get throws {
-            try XCTUnwrap(view[child: "An example licence"])
+            try XCTUnwrap(view[child: "imageView"])
         }
     }
     

--- a/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -52,8 +52,12 @@ public final class InstructionsWithImageViewController: BaseViewController, Titl
     /// Image view: ``UIImageView``
     @IBOutlet private var imageView: UIImageView! {
         didSet {
-            imageView.image = viewModel.imageWithLabel.image
-            imageView.accessibilityIdentifier = viewModel.imageWithLabel.imageLabel.value
+            if let viewModel = viewModel as? InstructionsWithImageWithAltTextViewModel {
+                imageView.accessibilityLabel = viewModel.imageAltText.value
+            }
+
+            imageView.image = viewModel.image
+            imageView.accessibilityIdentifier = "imageView"
         }
     }
     

--- a/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -52,8 +52,8 @@ public final class InstructionsWithImageViewController: BaseViewController, Titl
     /// Image view: ``UIImageView``
     @IBOutlet private var imageView: UIImageView! {
         didSet {
-            imageView.image = viewModel.image
-            imageView.accessibilityIdentifier = "imageView"
+            imageView.image = viewModel.imageWithLabel.image
+            imageView.accessibilityIdentifier = viewModel.imageWithLabel.imageLabel.value
         }
     }
     

--- a/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -10,17 +10,12 @@ import UIKit
 public protocol InstructionsWithImageViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }
-    var imageWithLabel: ImageWithLabel { get }
+    var image: UIImage { get }
     var warningButtonViewModel: ButtonViewModel? { get }
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
 
-public protocol InstructionsWithImageTypeViewModel {
-    var imageWithLabel: ImageWithLabel { get }
-}
-
-public protocol ImageWithLabel {
-    var image: UIImage { get }
-    var imageLabel: GDSLocalisedString { get }
+public protocol InstructionsWithImageWithAltTextViewModel {
+    var imageAltText: GDSLocalisedString { get }
 }

--- a/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -10,8 +10,17 @@ import UIKit
 public protocol InstructionsWithImageViewModel {
     var title: GDSLocalisedString { get }
     var body: NSAttributedString { get }
-    var image: UIImage { get }
+    var imageWithLabel: ImageWithLabel { get }
     var warningButtonViewModel: ButtonViewModel? { get }
     var primaryButtonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
+}
+
+public protocol InstructionsWithImageTypeViewModel {
+    var imageWithLabel: ImageWithLabel { get }
+}
+
+public protocol ImageWithLabel {
+    var image: UIImage { get }
+    var imageLabel: GDSLocalisedString { get }
 }


### PR DESCRIPTION
# DCMAW-10738: Refactor InstructionsWithImageViewModel

A new protocol, `ImageWithLabel` has been created and replaces the `image` property on `InstructionsWithImageViewModel`. This is so we can pass in an image and also assign the accessibility identifier to be the alt text designated on future tickets. 

The functionality of this ticket doesn't change, besides the above change. 

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
