### PR TITLE
fix: displays icon if present on centre aligned screen primary button

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -33,7 +33,7 @@ struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
 extension MockButtonViewModel {
     static var primary: MockButtonViewModel {
         MockButtonViewModel(title: "Action button",
-                            icon: nil,
+                            icon: MockButtonIconViewModel(iconName: "arrow.up.right", symbolPosition: .afterTitle),
                             shouldLoadOnTap: false,
                             action: {})
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -99,6 +99,18 @@ extension GDSCentreAlignedScreenTests {
         XCTAssertNil(try sut.primaryButton.icon)
     }
 
+    func test_primaryButtonHasIcon() throws {
+        primaryButtonViewModel = MockButtonViewModel(title: "Primary button with icon",
+                                                     icon: MockButtonIconViewModel()) {}
+        viewModel = MockGDSCentreAlignedViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                  secondaryButtonViewModel: secondaryButtonViewModel) {
+        } dismissAction: {
+        }
+        sut = GDSCentreAlignedScreen(viewModel: viewModel)
+        XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button with icon")
+        XCTAssertNotNil(try sut.primaryButton.icon)
+    }
+
     func test_secondaryButtonNoIcon() throws {
         XCTAssertNil(try sut.secondaryButton.icon)
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -104,7 +104,9 @@ extension GDSCentreAlignedScreenTests {
                                                      icon: MockButtonIconViewModel()) {}
         viewModel = MockGDSCentreAlignedViewModel(primaryButtonViewModel: primaryButtonViewModel,
                                                   secondaryButtonViewModel: secondaryButtonViewModel) {
+            // empty implementation
         } dismissAction: {
+            // empty implementation
         }
         sut = GDSCentreAlignedScreen(viewModel: viewModel)
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button with icon")
@@ -121,8 +123,9 @@ extension GDSCentreAlignedScreenTests {
         
         viewModel = MockGDSCentreAlignedViewModel(primaryButtonViewModel: primaryButtonViewModel,
                                                   secondaryButtonViewModel: secondaryButtonViewModel) {
+            // empty implementation
         } dismissAction: {
-            
+            // empty implementation
         }
         sut = GDSCentreAlignedScreen(viewModel: viewModel)
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary button with no icon")

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -166,6 +166,10 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             } else if let buttonViewModel = viewModel as? GDSCentreAlignedViewModelWithPrimaryButton {
                 primaryButton.setTitle(buttonViewModel.primaryButtonViewModel.title.value, for: .normal)
                 primaryButton.accessibilityHint = buttonViewModel.primaryButtonViewModel.accessibilityHint?.value
+                if let icon = buttonViewModel.primaryButtonViewModel.icon {
+                    primaryButton.symbolPosition = .afterTitle
+                    primaryButton.icon = icon.iconName
+                }
             } else {
                 primaryButton.isHidden = true
             }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -167,7 +167,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
                 primaryButton.setTitle(buttonViewModel.primaryButtonViewModel.title.value, for: .normal)
                 primaryButton.accessibilityHint = buttonViewModel.primaryButtonViewModel.accessibilityHint?.value
                 if let icon = buttonViewModel.primaryButtonViewModel.icon {
-                    primaryButton.symbolPosition = .afterTitle
+                    primaryButton.symbolPosition = icon.symbolPosition
                     primaryButton.icon = icon.iconName
                 }
             } else {


### PR DESCRIPTION
# Displays Icon on Centre Aligned Screen's Primary Button

As part of the work on DCMAW-11082 and implementing the MAM handback screen for the ID Check V2, the primary button for the Centre Aligned Screen needed an icon property to be set in the view controller. Therefore, this PR sets the icon if it is present in the view model. 

_Note: This will display in all mocks in the demo app where `MockButtonViewModel.primary` is used, but it is an optional property on the actual view model itself_

<img width="250" src="https://github.com/user-attachments/assets/4a45ea4d-9dcc-4e97-883a-48a67c9ea99d" />

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
