### PR TITLE
fix: adding MainActor isolation to URLOpener

### DIFF
--- a/Sources/GDSCommon/Utilities/URLOpener.swift
+++ b/Sources/GDSCommon/Utilities/URLOpener.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 public protocol URLOpener {
     func open(url: URL)
 }


### PR DESCRIPTION
# fix: adding MainActor isolation to URLOpener

Receiving Swift 6 warnings about passing UIApplication into a nonisolated context for the URLOpener protocol.
[UIApplication](https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)) is MainActor isolated so ensuring the protocol matches that

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
