### PR TITLE
feat: dcmaw-11848 new error pattern error screen

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
+++ b/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
@@ -681,7 +681,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -716,7 +716,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;

--- a/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
+++ b/GDSCommon-Demo/GDSCommon-Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03A7F4EC2D8D794700CFA364 /* ErrorScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A7F4EB2D8D794100CFA364 /* ErrorScreenTests.swift */; };
+		03A7F4F02D8D8D8C00CFA364 /* MockGDSErrorViewModelV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A7F4EE2D8D892B00CFA364 /* MockGDSErrorViewModelV3.swift */; };
 		1E3851602D0B179F00006E06 /* MockGDSCentreAlignedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E38515F2D0B179400006E06 /* MockGDSCentreAlignedViewModel.swift */; };
 		1E891B722B628AA000744E3D /* MockGDSInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E891B712B628AA000744E3D /* MockGDSInformationViewModel.swift */; };
 		1E891B772B63CCB000744E3D /* GDSCentreAlignedScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E891B762B63CCB000744E3D /* GDSCentreAlignedScreenTests.swift */; };
@@ -77,6 +79,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03A7F4EB2D8D794100CFA364 /* ErrorScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreenTests.swift; sourceTree = "<group>"; };
+		03A7F4EE2D8D892B00CFA364 /* MockGDSErrorViewModelV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSErrorViewModelV3.swift; sourceTree = "<group>"; };
 		1E38515F2D0B179400006E06 /* MockGDSCentreAlignedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSCentreAlignedViewModel.swift; sourceTree = "<group>"; };
 		1E891B712B628AA000744E3D /* MockGDSInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGDSInformationViewModel.swift; sourceTree = "<group>"; };
 		1E891B762B63CCB000744E3D /* GDSCentreAlignedScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDSCentreAlignedScreenTests.swift; sourceTree = "<group>"; };
@@ -160,6 +164,7 @@
 		2B0844012ABC79BB00188BA0 /* GDSCommon-DemoTests */ = {
 			isa = PBXGroup;
 			children = (
+				03A7F4EB2D8D794100CFA364 /* ErrorScreenTests.swift */,
 				7C51376E2AD99E9D00163E83 /* Mocks */,
 				968598AF2B03A7C300462D0B /* MockBase.xib */,
 				2B08440D2ABC7A4300188BA0 /* TestExtensions */,
@@ -262,6 +267,7 @@
 				968598AC2B03878900462D0B /* MockBaseViewModel.swift */,
 				7C51376F2AD99EB600163E83 /* Scanning */,
 				2BD04BF42B729A1C00AC5279 /* MockGDSCentreAlignedViewModel.swift */,
+				03A7F4EE2D8D892B00CFA364 /* MockGDSErrorViewModelV3.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -406,6 +412,7 @@
 			files = (
 				96588BEC2AD6AD8A0035FF93 /* TextInputViewControllerTests.swift in Sources */,
 				2B0844092ABC79C300188BA0 /* ModalInfoViewControllerTests.swift in Sources */,
+				03A7F4EC2D8D794700CFA364 /* ErrorScreenTests.swift in Sources */,
 				9634B46A2ACDAE8E00A60CC8 /* GDSListOptionsViewControllerTests.swift in Sources */,
 				96588BDC2AD02AB30035FF93 /* Date+Extensions.swift in Sources */,
 				D0726FA72BF77BE20043AEF1 /* GDSLoadingViewControllerTests.swift in Sources */,
@@ -422,6 +429,7 @@
 				C8A3955F2B20BA6700333669 /* GDSErrorViewControllerTests.swift in Sources */,
 				2B08440B2ABC79C300188BA0 /* MockGDSInstructionsViewModel.swift in Sources */,
 				7CBC376B2ADB01C200572312 /* MockCaptureSession.swift in Sources */,
+				03A7F4F02D8D8D8C00CFA364 /* MockGDSErrorViewModelV3.swift in Sources */,
 				2B0844112ABC7A7700188BA0 /* XCTestCase.swift in Sources */,
 				96588BE02AD046420035FF93 /* DatePickerScreenViewControllerTests.swift in Sources */,
 				2BB5C7892AD3F7DE006BE7E2 /* ScanningViewControllerTests.swift in Sources */,

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockBulletViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockBulletViewModel.swift
@@ -6,9 +6,18 @@ struct MockBulletViewModel: BulletViewModel {
     var titleFont: UIFont?
     var text: [String]
     
-    init(title: String? = "This is the bullet view",
-         titleFont: UIFont? = .init(style: .title2, weight: .bold),
-         text: [String] = ["Here we can list things we want the user to know", "we can use this as a way to step them through an action", "or give details of a process"]) {
+    init(
+        title: String? = "This is the bullet view",
+        titleFont: UIFont? = UIFont(
+            style: .title2,
+            weight: .bold
+        ),
+        text: [String] = [
+            "Here we can list things we want the user to know",
+            "we can use this as a way to step them through an action",
+            "or give details of a process"
+        ]
+    ) {
         self.title = title
         self.titleFont = titleFont
         self.text = text

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -46,6 +46,18 @@ extension MockButtonViewModel {
                             action: {})
     }
     
+    static var tertiary: MockButtonViewModel {
+        MockButtonViewModel(
+            title: "Tertiary Button",
+            icon: MockButtonIconViewModel(
+                iconName: "arrow.up.right",
+                symbolPosition: .afterTitle
+            ),
+            shouldLoadOnTap: false,
+            action: {}
+        )
+    }
+    
     static var secondaryQR: MockButtonViewModel {
         MockButtonViewModel(title: "Secondary Button",
                             icon: MockButtonIconViewModel(iconName: "qrcode",

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -7,6 +7,21 @@ struct MockButtonViewModel: ButtonViewModel {
     let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
     let action: () -> Void
+    let contentAlignment: UIControl.ContentHorizontalAlignment?
+    
+    public init(
+        title: GDSLocalisedString,
+        icon: ButtonIconViewModel?,
+        shouldLoadOnTap: Bool,
+        action: @escaping () -> Void,
+        contentAlignment: UIControl.ContentHorizontalAlignment? = .center
+    ) {
+        self.title = title
+        self.icon = icon
+        self.shouldLoadOnTap = shouldLoadOnTap
+        self.action = action
+        self.contentAlignment = contentAlignment
+    }
 }
 
 struct MockButtonIconViewModel: ButtonIconViewModel {
@@ -20,6 +35,7 @@ struct MockColoredButtonViewModel: ColoredButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
     let backgroundColor: UIColor
+    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
 }
 
 struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
@@ -28,6 +44,7 @@ struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
     let accessibilityHint: GDSLocalisedString?
+    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
 }
 
 extension MockButtonViewModel {
@@ -81,6 +98,32 @@ extension MockButtonViewModel {
                                              action: { },
                                              accessibilityHint: "This includes a voiceover hint")
     }
+    
+    static var textCentered: MockButtonViewModel {
+        MockButtonViewModel(
+            title: "Text Button",
+            icon: MockButtonIconViewModel(
+                iconName: "arrow.up.right",
+                symbolPosition: .afterTitle
+            ),
+            shouldLoadOnTap: false,
+            action: {}
+        )
+    }
+    
+    static var textLeading: MockButtonViewModel {
+        MockButtonViewModel(
+            title: "Text Button",
+            icon: MockButtonIconViewModel(
+                iconName: "arrow.up.right",
+                symbolPosition: .afterTitle
+            ),
+            shouldLoadOnTap: false,
+            action: {},
+            contentAlignment: UIControl.ContentHorizontalAlignment.leading
+        )
+    }
+    
 }
 
 extension MockColoredButtonViewModel {

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -7,20 +7,20 @@ struct MockButtonViewModel: ButtonViewModel {
     let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
     let action: () -> Void
-    let contentAlignment: UIControl.ContentHorizontalAlignment?
+    let overrideContentAlignment: UIControl.ContentHorizontalAlignment
     
     public init(
         title: GDSLocalisedString,
         icon: ButtonIconViewModel?,
         shouldLoadOnTap: Bool,
         action: @escaping () -> Void,
-        contentAlignment: UIControl.ContentHorizontalAlignment? = .center
+        overrideContentAlignment: UIControl.ContentHorizontalAlignment = .center
     ) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
         self.action = action
-        self.contentAlignment = contentAlignment
+        self.overrideContentAlignment = overrideContentAlignment
     }
 }
 
@@ -35,7 +35,7 @@ struct MockColoredButtonViewModel: ColoredButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
     let backgroundColor: UIColor
-    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
+    let overrideContentAlignment: UIControl.ContentHorizontalAlignment = .center
 }
 
 struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
@@ -44,7 +44,7 @@ struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
     let accessibilityHint: GDSLocalisedString?
-    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
+    let overrideContentAlignment: UIControl.ContentHorizontalAlignment = .center
 }
 
 extension MockButtonViewModel {
@@ -120,7 +120,7 @@ extension MockButtonViewModel {
             ),
             shouldLoadOnTap: false,
             action: {},
-            contentAlignment: UIControl.ContentHorizontalAlignment.leading
+            overrideContentAlignment: UIControl.ContentHorizontalAlignment.leading
         )
     }
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -1,6 +1,37 @@
 import GDSCommon
 import UIKit
 
+private func mockChildView(
+_ alignment: UIControl.ContentHorizontalAlignment = .left
+) -> UIView {
+    let label = UILabel()
+    label.font = UIFont(style: .body)
+    label.text = "This is a child view"
+    label.adjustsFontForContentSizeCategory = true
+    
+    let button = SecondaryButton()
+    button.setTitle(GDSLocalisedString("Text"), for: .normal)
+    button.contentHorizontalAlignment = alignment
+    button.titleLabel?.textColor = .gdsGreen
+    button.symbolPosition = .afterTitle
+    button.icon = "arrow.up.right"
+    
+    let buttonStack = UIStackView(
+        views: [button],
+        axis: .horizontal,
+        distribution: .fill
+    )
+        
+    return UIStackView(
+        views: [
+            label,
+            buttonStack
+        ],
+        alignment: .fill,
+        distribution: .equalSpacing
+    )
+}
+
 struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"
@@ -11,7 +42,113 @@ struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, Base
     let backButtonIsHidden: Bool = false
     
     func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = nil 
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
     
+    var childView: UIView? { mockChildView() }
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3Warning: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = nil
+    let voiceOverPrefix: String? = "Warning"
+    let title: GDSLocalisedString = "This is an Warning Error View title"
+    let body: GDSLocalisedString? = "This is an Warning Error View body that should span onto multiple lines"
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    var childView: UIView?
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3AppUpdate: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90"
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an App Update Error View title"
+    let body: GDSLocalisedString? = "This is an App Update Error View body that should span onto multiple lines"
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    var childView: UIView? { mockChildView() }
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = nil
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an modal Error View title"
+    let body: GDSLocalisedString? = "This is an modal Error View body that should span onto multiple lines"
+    let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
+    let backButtonIsHidden: Bool = false
+   
+    var childView: UIView? { mockChildView() }
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = nil
+    let voiceOverPrefix: String? = nil 
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+        
+    var childView: UIView? { mockChildView(.center) }
+    var buttonViewModels: [any ButtonViewModel] = []
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel {
+    var image: String? = nil
+    let voiceOverPrefix: String? = nil 
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    var childView: UIView? { mockChildView() }
+    
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary,
+        MockButtonViewModel.tertiary
+    ]
+    
+    func didAppear() {}
     func didDismiss() {}
 }
 
@@ -24,7 +161,6 @@ struct MockErrorViewModelNoIcon: GDSErrorViewModelV2, BaseViewModel {
     let backButtonIsHidden: Bool = false
     
     func didAppear() {}
-    
     func didDismiss() {}
 }
 
@@ -39,6 +175,5 @@ struct MockErrorViewModelWithTertiary: GDSErrorViewModelV2, GDSErrorViewModelWit
     let backButtonIsHidden: Bool = false
     
     func didAppear() {}
-    
     func didDismiss() {}
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -1,26 +1,26 @@
 import GDSCommon
 import UIKit
 
-private var singleLineRegular: ScreenBodyItem {
+var singleLineRegular: ScreenBodyItem {
     BodyTextViewModel(
         text: "Body single line (regular)"
     )
 }
 
-private var singleLineBold: ScreenBodyItem {
+var singleLineBold: ScreenBodyItem {
     BodyTextViewModel(
         text: "Body single line (body)",
         fontWeight: .bold
     )
 }
 
-private var singleParagraph: ScreenBodyItem {
+var singleParagraph: ScreenBodyItem {
     BodyTextViewModel(
         text: "Body single paragraph - Lorem ipsum dolor sit amet consectetur. Purus aliquam mattis vitae enim mauris vestibulum massa tellus.)"
     )
 }
  
-private var multipleParagraph: ScreenBodyItem {
+var multipleParagraph: ScreenBodyItem {
     BodyTextViewModel(
         text:
         """
@@ -45,8 +45,7 @@ struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, Base
 }
 
 struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an Error View title"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
@@ -64,8 +63,7 @@ struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an Error View title"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
@@ -86,8 +84,7 @@ struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an Error View title"
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
@@ -110,8 +107,7 @@ struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel 
 }
 
 struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an modal Error View title"
     let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
     let backButtonIsHidden: Bool = false
@@ -132,8 +128,7 @@ struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3Warning: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = "Warning"
+    var image: ErrorScreenImage = .warning
     let title: GDSLocalisedString = "This is an Warning Error View title"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
@@ -154,8 +149,7 @@ struct MockErrorViewModelV3Warning: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3AppUpdate: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90"
-    let voiceOverPrefix: String? = nil
+    var image: ErrorScreenImage = .appUpdate
     let title: GDSLocalisedString = "This is an App Update Error View title"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -16,7 +16,7 @@ var singleLineBold: ScreenBodyItem {
 
 var singleParagraph: ScreenBodyItem {
     BodyTextViewModel(
-        text: "Body single paragraph - Lorem ipsum dolor sit amet consectetur. Purus aliquam mattis vitae enim mauris vestibulum massa tellus.)"
+        text: "Body single paragraph - Lorem ipsum dolor sit amet consectetur. Purus aliquam mattis vitae enim mauris vestibulum massa tellus."
     )
 }
  

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -1,34 +1,33 @@
 import GDSCommon
 import UIKit
 
-private func mockChildView(
-_ alignment: UIControl.ContentHorizontalAlignment = .left
-) -> UIView {
-    let label = UILabel()
-    label.font = UIFont(style: .body)
-    label.text = "This is a child view"
-    label.adjustsFontForContentSizeCategory = true
-    
-    let button = SecondaryButton()
-    button.setTitle(GDSLocalisedString("Text"), for: .normal)
-    button.contentHorizontalAlignment = alignment
-    button.titleLabel?.textColor = .gdsGreen
-    button.symbolPosition = .afterTitle
-    button.icon = "arrow.up.right"
-    
-    let buttonStack = UIStackView(
-        views: [button],
-        axis: .horizontal,
-        distribution: .fill
+private var singleLineRegular: ScreenBodyItem {
+    BodyTextViewModel(
+        text: "Body single line (regular)"
     )
-        
-    return UIStackView(
-        views: [
-            label,
-            buttonStack
-        ],
-        alignment: .fill,
-        distribution: .equalSpacing
+}
+
+private var singleLineBold: ScreenBodyItem {
+    BodyTextViewModel(
+        text: "Body single line (body)",
+        fontWeight: .bold
+    )
+}
+
+private var singleParagraph: ScreenBodyItem {
+    BodyTextViewModel(
+        text: "Body single paragraph - Lorem ipsum dolor sit amet consectetur. Purus aliquam mattis vitae enim mauris vestibulum massa tellus.)"
+    )
+}
+ 
+private var multipleParagraph: ScreenBodyItem {
+    BodyTextViewModel(
+        text:
+        """
+            Body multiple paragraphs - Lorem ipsum dolor sit amet consectetur.
+            
+            Purus aliquam mattis vitae enim mauris vestibulum massa tellus.
+        """
     )
 }
 
@@ -45,15 +44,84 @@ struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, Base
     func didDismiss() {}
 }
 
+struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
+    var image: String?
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an Error View title"
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineRegular,
+        singleParagraph,
+        MockBulletViewModel(),
+        MockButtonViewModel.textLeading
+    ]
+    var buttonViewModels: [any ButtonViewModel] = []
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
 struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
     var image: String?
     let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an Error View title"
-    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
     
-    var childView: UIView? { mockChildView() }
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineRegular,
+        multipleParagraph,
+        MockButtonViewModel.textCentered
+    ]
+    
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel {
+    var image: String?
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an Error View title"
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = false
+    
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineRegular,
+        singleParagraph,
+        MockButtonViewModel.textCentered
+    ]
+    
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary,
+        MockButtonViewModel.tertiary
+    ]
+    
+    func didAppear() {}
+    func didDismiss() {}
+}
+
+struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
+    var image: String?
+    let voiceOverPrefix: String? = nil
+    let title: GDSLocalisedString = "This is an modal Error View title"
+    let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
+    let backButtonIsHidden: Bool = false
+    
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineRegular,
+        singleParagraph,
+        MockBulletViewModel(),
+        MockButtonViewModel.textLeading
+    ]
     var buttonViewModels: [any ButtonViewModel] = [
         MockButtonViewModel.primary,
         MockButtonViewModel.secondary
@@ -67,11 +135,15 @@ struct MockErrorViewModelV3Warning: GDSErrorViewModelV3, BaseViewModel {
     var image: String?
     let voiceOverPrefix: String? = "Warning"
     let title: GDSLocalisedString = "This is an Warning Error View title"
-    let body: GDSLocalisedString? = "This is an Warning Error View body that should span onto multiple lines"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
     
-    var childView: UIView?
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineBold,
+        singleParagraph,
+        MockButtonViewModel.textCentered
+    ]
+    
     var buttonViewModels: [any ButtonViewModel] = [
         MockButtonViewModel.primary,
         MockButtonViewModel.secondary
@@ -85,67 +157,17 @@ struct MockErrorViewModelV3AppUpdate: GDSErrorViewModelV3, BaseViewModel {
     var image: String? = "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90"
     let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an App Update Error View title"
-    let body: GDSLocalisedString? = "This is an App Update Error View body that should span onto multiple lines"
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
     
-    var childView: UIView? { mockChildView() }
+    var bodyContent: [ScreenBodyItem] = [
+        singleLineRegular,
+        singleParagraph,
+        MockButtonViewModel.textCentered
+    ]
+    
     var buttonViewModels: [any ButtonViewModel] = [
         MockButtonViewModel.primary
-    ]
-    
-    func didAppear() {}
-    func didDismiss() {}
-}
-
-struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
-    let title: GDSLocalisedString = "This is an modal Error View title"
-    let body: GDSLocalisedString? = "This is an modal Error View body that should span onto multiple lines"
-    let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
-    let backButtonIsHidden: Bool = false
-   
-    var childView: UIView? { mockChildView() }
-    var buttonViewModels: [any ButtonViewModel] = [
-        MockButtonViewModel.primary,
-        MockButtonViewModel.secondary
-    ]
-    
-    func didAppear() {}
-    func didDismiss() {}
-}
-
-struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
-    let title: GDSLocalisedString = "This is an Error View title"
-    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
-    let rightBarButtonTitle: GDSLocalisedString? = nil
-    let backButtonIsHidden: Bool = false
-        
-    var childView: UIView? { mockChildView(.center) }
-    var buttonViewModels: [any ButtonViewModel] = []
-    
-    func didAppear() {}
-    func didDismiss() {}
-}
-
-struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String?
-    let voiceOverPrefix: String? = nil
-    let title: GDSLocalisedString = "This is an Error View title"
-    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
-    
-    let rightBarButtonTitle: GDSLocalisedString? = nil
-    let backButtonIsHidden: Bool = false
-    
-    var childView: UIView? { mockChildView() }
-    
-    var buttonViewModels: [any ButtonViewModel] = [
-        MockButtonViewModel.primary,
-        MockButtonViewModel.secondary,
-        MockButtonViewModel.tertiary
     ]
     
     func didAppear() {}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -46,7 +46,7 @@ struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, Base
 }
 
 struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = nil 
+    var image: String?
     let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
@@ -64,7 +64,7 @@ struct MockErrorViewModelV3WithTwoButtons: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3Warning: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = nil
+    var image: String?
     let voiceOverPrefix: String? = "Warning"
     let title: GDSLocalisedString = "This is an Warning Error View title"
     let body: GDSLocalisedString? = "This is an Warning Error View body that should span onto multiple lines"
@@ -99,7 +99,7 @@ struct MockErrorViewModelV3AppUpdate: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = nil
+    var image: String?
     let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an modal Error View title"
     let body: GDSLocalisedString? = "This is an modal Error View body that should span onto multiple lines"
@@ -117,8 +117,8 @@ struct MockErrorViewModelV3Modal: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = nil
-    let voiceOverPrefix: String? = nil 
+    var image: String?
+    let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
     let rightBarButtonTitle: GDSLocalisedString? = nil
@@ -132,8 +132,8 @@ struct MockErrorViewModelV3WithNoButtons: GDSErrorViewModelV3, BaseViewModel {
 }
 
 struct MockErrorViewModelV3WithThreeButtons: GDSErrorViewModelV3, BaseViewModel {
-    var image: String? = nil
-    let voiceOverPrefix: String? = nil 
+    var image: String?
+    let voiceOverPrefix: String? = nil
     let title: GDSLocalisedString = "This is an Error View title"
     let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
     

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
@@ -22,5 +22,5 @@ struct MockOptionButtonViewModel: ButtonViewModel {
     let icon: ButtonIconViewModel? = nil
     let shouldLoadOnTap: Bool = true
     let action: () -> Void = { }
-    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
+    let overrideContentAlignment: UIControl.ContentHorizontalAlignment = .center
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
@@ -1,4 +1,5 @@
 import GDSCommon
+import UIKit
 
 struct MockOptionViewModel1: OptionViewModel {
     let title: GDSLocalisedString = "Example title text 1"
@@ -21,4 +22,5 @@ struct MockOptionButtonViewModel: ButtonViewModel {
     let icon: ButtonIconViewModel? = nil
     let shouldLoadOnTap: Bool = true
     let action: () -> Void = { }
+    let contentAlignment: UIControl.ContentHorizontalAlignment? = .center
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -13,6 +13,12 @@ import UIKit
 ///             the view as a `UIViewController` to push/present on the navigation stack.
 @MainActor
 enum Screens: String, CaseIterable {
+    case gdsErrorScreenNoButtons = "Design System Error Screen (with no buttons)"
+    case gdsErrorScreen = "Design System Error Screen (with 2 buttons)"
+    case gdsErrorScreen3Buttons = "Design System Error Screen (with 3 buttons)"
+    case gdsErrorScreenModal = "Design System Error Screen (modal)"
+    case gdsErrorScreenWarning = "Design System Error Screen (warning)"
+    case gdsErrorScreenAppUpdate = "Design System Error Screen (app update)"
     case gdsInstructions = "GDS Instructions View"
     case gdsInstructionsWithColouredButton = "GDS Instructions View (with coloured button)"
     case gdsInstructionsWithImage = "GDS Instructions View (with image)"
@@ -44,7 +50,8 @@ enum Screens: String, CaseIterable {
                 .gdsQRCodeScannerModal,
                 .gdsResultsViewModal,
                 .gdsAttributedModalInfoView,
-                .gdsInstructionsWithImageModally:
+                .gdsInstructionsWithImageModally,
+                .gdsErrorScreenModal:
             return true
         default:
             return false
@@ -52,8 +59,10 @@ enum Screens: String, CaseIterable {
     }
     
     private var dialogPresenter: DialogPresenter {
-        DialogView<CheckmarkDialogAccessoryView>(title: "QR Scan Success",
-                                                 isLoading: false)
+        DialogView<CheckmarkDialogAccessoryView>(
+            title: "QR Scan Success",
+            isLoading: false
+        )
     }
     
     // swiftlint:disable function_body_length
@@ -62,37 +71,55 @@ enum Screens: String, CaseIterable {
         case .gdsInstructions:
             return GDSInstructionsViewController(popToRoot: popToRoot, navController: navigationController)
         case .gdsInstructionsWithColouredButton:
-            let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockColoredButtonViewModel.primary,
-                                                         secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
-                                                         dismissAction: { })
+            let viewModel = MockGDSInstructionsViewModel(
+                buttonViewModel: MockColoredButtonViewModel.primary,
+                secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
+                dismissAction: { }
+            )
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
-                                                               primaryButtonViewModel: MockButtonViewModel.primary,
-                                                               screenView: { }, dismissAction: { })
+            let viewModel = MockInstructionsWithImageViewModel(
+                warningButtonViewModel: MockButtonViewModel.primary,
+                primaryButtonViewModel: MockButtonViewModel.primary,
+                screenView: { },
+                dismissAction: { }
+            )
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsInstructionsWithImageModally:
-            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: MockButtonViewModel.primary,
-                                                               primaryButtonViewModel: MockButtonViewModel.primary,
-                                                               secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
-                                                               rightBarButtonTitle: "Close",
-                                                               screenView: { }, dismissAction: { })
+            let viewModel = MockInstructionsWithImageViewModel(
+                warningButtonViewModel: MockButtonViewModel.primary,
+                primaryButtonViewModel: MockButtonViewModel.primary,
+                secondaryButtonViewModel: MockButtonViewModel.secondaryQR,
+                rightBarButtonTitle: "Close",
+                screenView: { },
+                dismissAction: { }
+            )
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsModalInfoView:
             let view = ModalInfoViewController(viewModel: MockModalInfoViewModel())
             return view
         case .gdsModalButtonsInfoView:
-            let view = ModalInfoViewController(viewModel: MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel.primary,
-                                                                                        secondaryButtonViewModel: MockButtonViewModel.secondary,
-                                                                                        textButtonViewModel: MockButtonViewModel.secondary))
+            let view = ModalInfoViewController(
+                viewModel: MockModalInfoButtonsViewModel(
+                    primaryButtonViewModel: MockButtonViewModel.primary,
+                    secondaryButtonViewModel: MockButtonViewModel.secondary,
+                    textButtonViewModel: MockButtonViewModel.secondary
+                )
+            )
             return view
         case .gdsAttributedModalInfoView:
             let view = ModalInfoViewController(viewModel: MockAttributedModalInfoViewModel())
             return view
         case .gdsListOptions:
-            return GDSListOptionsViewController(popToRoot: popToRoot, navController: navigationController)
+            return GDSListOptionsViewController(
+                popToRoot: popToRoot,
+                navController: navigationController
+            )
         case .gdsIntroView:
-            let viewModel = MockIntroViewModel(introButtonViewModel: MockButtonViewModel.primary, rightBarButtonTitle: nil)
+            let viewModel = MockIntroViewModel(
+                introButtonViewModel: MockButtonViewModel.primary,
+                rightBarButtonTitle: nil
+            )
             return IntroViewController(viewModel: viewModel)
         case .gdsDatePicker:
             return DatePickerScreenViewController()
@@ -101,10 +128,15 @@ enum Screens: String, CaseIterable {
         case .gdsIconScreen:
             return IconScreenViewController()
         case .gdsQRCodeScanner:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.popViewController(animated: true) } dismissAction: { }
+            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.popViewController(animated: true)
+            }
+            dismissAction: { }
             return ScanningViewController(viewModel: viewModel)
         case .gdsQRCodeScannerModal:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.dismiss(animated: true) } dismissAction: { }
+            let viewModel = MockQRScanningViewModel(
+                dialogPresenter: dialogPresenter
+            ) { navigationController.dismiss(animated: true) }
+            dismissAction: { }
             return ScanningViewController(viewModel: viewModel)
         case .gdsResultsView:
             return ResultsViewController(popToRoot: popToRoot, navController: navigationController)
@@ -124,6 +156,19 @@ enum Screens: String, CaseIterable {
             return GDSCentreAlignedScreen(viewModel: MockGDSCentreAlignedViewModel())
         case .gdsLoadingView:
             return GDSLoadingViewController()
+        
+        case .gdsErrorScreen:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3WithTwoButtons())
+        case .gdsErrorScreenModal:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3Modal())
+        case .gdsErrorScreenNoButtons:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3WithNoButtons())
+        case .gdsErrorScreen3Buttons:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3WithThreeButtons())
+        case .gdsErrorScreenWarning:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3Warning())
+        case .gdsErrorScreenAppUpdate:
+            return GDSErrorScreen(viewModel: MockErrorViewModelV3AppUpdate())
         }
     }
     // swiftlint:enable function_body_length

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
@@ -120,11 +120,6 @@ extension GDSErrorScreenTests {
         XCTAssertEqual(try sut.titleLabel.text, "This is an Error View title")
         XCTAssertEqual(try sut.titleLabel.font, .largeTitleBold)
         XCTAssertTrue(try sut.titleLabel.accessibilityTraits.contains(.header))
-        XCTAssertEqual(try sut.bodyLabel.text, "This is an Error View body that should span onto multiple lines")
-        XCTAssertFalse(try sut.bodyLabel.accessibilityTraits.contains(.header))
-       
-        // Child View
-        XCTAssertNotNil(try sut.childView)
        
         // Buttons
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary Action")
@@ -238,6 +233,8 @@ extension GDSErrorScreenTests {
         XCTAssertNotNil(sut.view[child: "error-screen-button-1"]) // Secondary
         XCTAssertNotNil(sut.view[child: "error-screen-button-2"]) // Tertiary
     }
+    
+    // TODO: Add tests for BodyContentItems
   
 }
 
@@ -251,12 +248,6 @@ extension GDSErrorScreen {
     var titleLabel: UILabel {
         get throws {
             try XCTUnwrap(view[child: "error-screen-title"])
-        }
-    }
-    
-    var bodyLabel: UILabel {
-        get throws {
-            try XCTUnwrap(view[child: "error-screen-body"])
         }
     }
     
@@ -278,9 +269,9 @@ extension GDSErrorScreen {
         }
     }
     
-    var childView: UIStackView {
+    var bodyContentView: UIStackView {
         get throws {
-            try XCTUnwrap(view[child: "error-screen-child-view"])
+            try XCTUnwrap(view[child: "error-screen-body-content-stack-view"])
         }
     }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
@@ -1,0 +1,292 @@
+@testable import GDSCommon
+import XCTest
+
+final class GDSErrorScreenTests: XCTestCase {
+    var viewModel: GDSErrorViewModelV3!
+    var sut: GDSErrorScreen!
+    
+    var buttonViewModels: [MockButtonViewModel] = []
+    var secondaryButtonViewModel: MockButtonViewModel!
+    var didTap_primaryButton = false
+    var didTap_secondaryButton = false
+    var didTap_tertiaryButton = false
+    var viewDidAppear = false
+    var viewDidDismiss = false
+    
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        sut = createSUT(image: "exclamationmark.circle")
+    }
+    
+    // swiftlint: disable function_body_length
+    @MainActor
+    private func createSUT(
+        image: String? = nil,
+        buttonsToAdd: Int = 3,
+        voiceOverPrefix: String? = "Error"
+    ) -> GDSErrorScreen {
+        let primaryButtonViewModel = MockButtonViewModel(
+            title: "Primary Action",
+            icon: nil,
+            shouldLoadOnTap: false,
+            voiceOverHint: "Button hint",
+            action: {
+                self.didTap_primaryButton = true
+            }
+        )
+        let secondaryButtonViewModel = MockButtonViewModel(
+            title: "Secondary Action",
+            icon: MockButtonIconViewModel(),
+            shouldLoadOnTap: false,
+            voiceOverHint: "Button hint",
+            action: {
+                self.didTap_secondaryButton = true
+            }
+        )
+        
+        let tertiaryButtonViewModel = MockButtonViewModel(
+            title: "Tertiary Action",
+            icon: MockButtonIconViewModel(),
+            shouldLoadOnTap: false,
+            voiceOverHint: "Button hint",
+            action: {
+                self.didTap_tertiaryButton = true
+            }
+        )
+        
+        switch buttonsToAdd {
+        case 1:
+            self.buttonViewModels = [
+                primaryButtonViewModel
+            ]
+        case 2:
+            self.buttonViewModels = [
+                primaryButtonViewModel,
+                secondaryButtonViewModel
+            ]
+        case 3:
+            self.buttonViewModels = [
+                primaryButtonViewModel,
+                secondaryButtonViewModel,
+                tertiaryButtonViewModel
+            ]
+            
+        default:
+            self.buttonViewModels = []
+        }
+        
+        let viewModel = MockErrorViewModelV3(
+            buttonViewModels: buttonViewModels,
+            image: image,
+            voiceOverPrefix: voiceOverPrefix,
+            appearAction: {
+                self.viewDidAppear = true
+            },
+            dismissAction: {
+                self.viewDidDismiss = true
+            }
+        )
+        
+        self.viewModel = viewModel
+        return GDSErrorScreen(viewModel: viewModel)
+        
+    }
+    // swiftlint: enable function_body_length
+    
+    override func tearDown() {
+        buttonViewModels = []
+        viewModel = nil
+        sut = nil
+        
+        didTap_primaryButton = false
+        didTap_secondaryButton = false
+        didTap_tertiaryButton = false
+        viewDidAppear = false
+        viewDidDismiss = false
+        
+        super.tearDown()
+    }
+}
+
+@MainActor
+extension GDSErrorScreenTests {
+    func test_viewContents_asExpected() throws {
+        // Icon Image
+        XCTAssertNotNil(try sut.image)
+        XCTAssertEqual(try sut.image.tintColor, .gdsPrimary)
+        
+        // Labels
+        XCTAssertEqual(try sut.titleLabel.text, "This is an Error View title")
+        XCTAssertEqual(try sut.titleLabel.font, .largeTitleBold)
+        XCTAssertTrue(try sut.titleLabel.accessibilityTraits.contains(.header))
+        XCTAssertEqual(try sut.bodyLabel.text, "This is an Error View body that should span onto multiple lines")
+        XCTAssertFalse(try sut.bodyLabel.accessibilityTraits.contains(.header))
+       
+        // Child View
+        XCTAssertNotNil(try sut.childView)
+       
+        // Buttons
+        XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary Action")
+        XCTAssertEqual(try sut.primaryButton.accessibilityHint, "Button hint")
+        XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary Action")
+        XCTAssertEqual(try sut.secondaryButton.accessibilityHint, "Button hint")
+        XCTAssertEqual(try sut.tertiaryButton.title(for: .normal), "Tertiary Action")
+        XCTAssertEqual(try sut.tertiaryButton.accessibilityHint, "Button hint")
+    }
+    
+    
+    func test_primaryButtonNoIcon() throws {
+        XCTAssertNil(try sut.primaryButton.icon)
+    }
+
+    func test_secondaryButtonHasIcon() throws {
+        XCTAssertEqual(try sut.secondaryButton.icon, "arrow.up.right")
+    }
+    
+    func test_tertiaryButtonHasIcon() throws {
+        XCTAssertEqual(try sut.tertiaryButton.icon, "arrow.up.right")
+    }
+    
+    func test_primaryButtonAction() throws {
+        XCTAssertFalse(didTap_primaryButton)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didTap_primaryButton)
+    }
+    
+    func test_secondaryButtonAction() throws {
+        XCTAssertFalse(didTap_secondaryButton)
+        try sut.secondaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didTap_secondaryButton)
+    }
+        
+    func test_tertiaryButtonAction() throws {
+        XCTAssertFalse(didTap_tertiaryButton)
+        try sut.tertiaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didTap_tertiaryButton)
+    }
+    
+    func test_didAppear() throws {
+        XCTAssertFalse(viewDidAppear)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+        XCTAssertTrue(viewDidAppear)
+    }
+    
+    func test_voiceOverFocusElement() throws {
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+        
+        let screen = try XCTUnwrap(sut as VoiceOverFocus)
+        let view = try XCTUnwrap(screen.initialVoiceOverView as? UILabel)
+        XCTAssertEqual(view.text, "This is an Error View title")
+    }
+    
+    func test_didDismiss() {
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+        
+        XCTAssertFalse(viewDidDismiss)
+        _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
+        XCTAssertTrue(viewDidDismiss)
+    }
+    
+    func test_imageIsNotHidden() throws {
+        XCTAssertFalse(try sut.image.isHidden)
+    }
+    
+    func test_errorScreenWithNoButtons() throws {
+        // GIVEN we setup the SUT with no buttons
+        sut = createSUT(buttonsToAdd: 0)
+        
+        // THEN all buttons should be nil
+        XCTAssertEqual(try sut.buttonStack.arrangedSubviews.count, 0)
+        XCTAssertNil(sut.view[child: "error-screen-button-0"]) // Primary
+        XCTAssertNil(sut.view[child: "error-screen-button-1"]) // Secondary
+        XCTAssertNil(sut.view[child: "error-screen-button-2"]) // Tertiary
+    }
+    
+    func test_errorScreenWithOneButton() throws {
+        // GIVEN we setup the SUT with 1 button
+        sut = createSUT(buttonsToAdd: 1)
+        
+        // THEN primary should not be nil, but secondary and tertiary should be nil
+        XCTAssertEqual(try sut.buttonStack.arrangedSubviews.count, 1)
+        XCTAssertNotNil(sut.view[child: "error-screen-button-0"]) // Primary
+        XCTAssertNil(sut.view[child: "error-screen-button-1"]) // Secondary
+        XCTAssertNil(sut.view[child: "error-screen-button-2"]) // Tertiary
+    }
+    
+    func test_errorScreenWithTwoButtons() throws {
+        // GIVEN we setup the SUT with 2 buttons
+        sut = createSUT(buttonsToAdd: 2)
+                
+        // THEN primary and secondary should not be nil, but tertiary should be nil
+        XCTAssertEqual(try sut.buttonStack.arrangedSubviews.count, 2)
+        XCTAssertNotNil(sut.view[child: "error-screen-button-0"]) // Primary
+        XCTAssertNotNil(sut.view[child: "error-screen-button-1"]) // Secondary
+        XCTAssertNil(sut.view[child: "error-screen-button-2"]) // Tertiary
+    }
+    
+    func test_errorScreenWithThreeButtons() throws {
+        // GIVEN we setup the SUT with 3 buttons
+        sut = createSUT(buttonsToAdd: 3)
+        
+        // THEN all buttons should be not be nil
+        XCTAssertEqual(try sut.buttonStack.arrangedSubviews.count, 3)
+        XCTAssertNotNil(sut.view[child: "error-screen-button-0"]) // Primary
+        XCTAssertNotNil(sut.view[child: "error-screen-button-1"]) // Secondary
+        XCTAssertNotNil(sut.view[child: "error-screen-button-2"]) // Tertiary
+    }
+  
+}
+
+extension GDSErrorScreen {
+    var image: UIImageView {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-image"])
+        }
+    }
+    
+    var titleLabel: UILabel {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-title"])
+        }
+    }
+    
+    var bodyLabel: UILabel {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-body"])
+        }
+    }
+    
+    var primaryButton: RoundedButton {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-button-0"])
+        }
+    }
+    
+    var secondaryButton: SecondaryButton {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-button-1"])
+        }
+    }
+    
+    var tertiaryButton: SecondaryButton {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-button-2"])
+        }
+    }
+    
+    var childView: UIStackView {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-child-view"])
+        }
+    }
+    
+    var buttonStack: UIStackView {
+        get throws {
+            try XCTUnwrap(view[child: "error-screen-button-stack-view"])
+        }
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -70,7 +70,6 @@ extension GDSCentreAlignedScreenTests {
     }
 
     func test_footnoteMovesToScrollView() throws {
-        sut.loadView()
         // When bottom stack height is half of the screen size
         try sut.bottomStack.frame.size.height = UIScreen.main.bounds.height / 2
         sut.viewDidLayoutSubviews()
@@ -80,7 +79,6 @@ extension GDSCentreAlignedScreenTests {
     }
     
     func test_footnoteMovesToBackToStackView() throws {
-        sut.loadView()
         // When bottom stack height is half of the screen size
         try sut.bottomStack.frame.size.height = UIScreen.main.bounds.height / 2
         sut.viewDidLayoutSubviews()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -178,13 +178,22 @@ struct MockButtonViewModel: ButtonViewModel {
     let shouldLoadOnTap: Bool
     let action: () -> Void
     let accessibilityHint: GDSLocalisedString?
+    var contentAlignment: UIControl.ContentHorizontalAlignment?
     
-    init(title: GDSLocalisedString, icon: ButtonIconViewModel? = nil, shouldLoadOnTap: Bool = false, voiceOverHint: GDSLocalisedString? = nil, action: @escaping () -> Void) {
+    init(
+        title: GDSLocalisedString,
+        icon: ButtonIconViewModel? = nil,
+        shouldLoadOnTap: Bool = false,
+        voiceOverHint: GDSLocalisedString? = nil,
+        contentAlignment: UIControl.ContentHorizontalAlignment? = .center,
+        action: @escaping () -> Void
+    ) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
         self.action = action
         self.accessibilityHint = voiceOverHint
+        self.contentAlignment = contentAlignment
     }
 }
 
@@ -192,14 +201,23 @@ struct MockColoredButtonViewModel: ColoredButtonViewModel {
     let title: GDSLocalisedString
     let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
-    let action: () -> Void
     let backgroundColor: UIColor
+    let contentAlignment: UIControl.ContentHorizontalAlignment?
+    let action: () -> Void
     
-    init(title: GDSLocalisedString, icon: ButtonIconViewModel? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void, backgroundColor: UIColor) {
+    init(
+        title: GDSLocalisedString,
+        icon: ButtonIconViewModel? = nil,
+        shouldLoadOnTap: Bool = false,
+        contentAlignment: UIControl.ContentHorizontalAlignment? = .center,
+        action: @escaping () -> Void,
+        backgroundColor: UIColor
+    ) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
         self.action = action
         self.backgroundColor = backgroundColor
+        self.contentAlignment = contentAlignment
     }
 }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
@@ -1,0 +1,49 @@
+@testable import GDSCommon
+import XCTest
+
+struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
+    var image: String?
+    let voiceOverPrefix: String?
+    let title: GDSLocalisedString = "This is an Error View title"
+    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
+    let backButtonIsHidden: Bool = false
+    let appearAction: () -> Void
+    let dismissAction: () -> Void
+    
+    var childView: UIView? {
+        let childViewLabel = UILabel()
+        childViewLabel.font = UIFont(style: .body)
+        childViewLabel.text = "This is a child view"
+        return UIStackView(
+            views: [
+                childViewLabel
+            ]
+        )
+    }
+    
+    var buttonViewModels: [any ButtonViewModel]
+    
+    public init(
+        buttonViewModels: [any ButtonViewModel],
+        image: String? = nil,
+        voiceOverPrefix: String? = nil,
+        appearAction: @escaping () -> Void,
+        dismissAction: @escaping () -> Void
+    ) {
+        self.buttonViewModels = buttonViewModels
+        self.image = image
+        self.voiceOverPrefix = voiceOverPrefix
+        self.appearAction = appearAction
+        self.dismissAction = dismissAction
+    }
+    
+    func didAppear() {
+        appearAction()
+    }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
@@ -2,6 +2,7 @@
 import XCTest
 
 struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
+    
     var image: String?
     let voiceOverPrefix: String?
     let title: GDSLocalisedString = "This is an Error View title"
@@ -12,6 +13,7 @@ struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
     let appearAction: () -> Void
     let dismissAction: () -> Void
     
+    var bodyContent: [any GDSCommon.ScreenBodyItem]
     var childView: UIView? {
         let childViewLabel = UILabel()
         childViewLabel.font = UIFont(style: .body)
@@ -29,12 +31,14 @@ struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
         buttonViewModels: [any ButtonViewModel],
         image: String? = nil,
         voiceOverPrefix: String? = nil,
+        bodyContent: [ScreenBodyItem] = [],
         appearAction: @escaping () -> Void,
         dismissAction: @escaping () -> Void
     ) {
         self.buttonViewModels = buttonViewModels
         self.image = image
         self.voiceOverPrefix = voiceOverPrefix
+        self.bodyContent = bodyContent
         self.appearAction = appearAction
         self.dismissAction = dismissAction
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSErrorViewModelV3.swift
@@ -3,10 +3,8 @@ import XCTest
 
 struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
     
-    var image: String?
-    let voiceOverPrefix: String?
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an Error View title"
-    let body: GDSLocalisedString? = "This is an Error View body that should span onto multiple lines"
     
     let rightBarButtonTitle: GDSLocalisedString? = "Cancel"
     let backButtonIsHidden: Bool = false
@@ -14,30 +12,17 @@ struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
     let dismissAction: () -> Void
     
     var bodyContent: [any GDSCommon.ScreenBodyItem]
-    var childView: UIView? {
-        let childViewLabel = UILabel()
-        childViewLabel.font = UIFont(style: .body)
-        childViewLabel.text = "This is a child view"
-        return UIStackView(
-            views: [
-                childViewLabel
-            ]
-        )
-    }
-    
     var buttonViewModels: [any ButtonViewModel]
     
     public init(
         buttonViewModels: [any ButtonViewModel],
-        image: String? = nil,
-        voiceOverPrefix: String? = nil,
+        image: ErrorScreenImage,
         bodyContent: [ScreenBodyItem] = [],
         appearAction: @escaping () -> Void,
         dismissAction: @escaping () -> Void
     ) {
         self.buttonViewModels = buttonViewModels
         self.image = image
-        self.voiceOverPrefix = voiceOverPrefix
         self.bodyContent = bodyContent
         self.appearAction = appearAction
         self.dismissAction = dismissAction

--- a/Sources/GDSCommon/Components/BodyTextViewModel.swift
+++ b/Sources/GDSCommon/Components/BodyTextViewModel.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+public struct BodyTextViewModel: ScreenBodyItem {
+    var text: String
+    var fontWeight: UIFont.Weight
+    var overridingAlignment: NSTextAlignment?
+    
+    public init(
+        text: String,
+        fontWeight: UIFont.Weight = .regular,
+        overridingAlignment: NSTextAlignment? = nil
+    ) {
+        self.text = text
+        self.fontWeight = fontWeight
+        self.overridingAlignment = overridingAlignment
+    }
+}

--- a/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
+++ b/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 @MainActor
-public protocol BulletViewModel {
+public protocol BulletViewModel: ScreenBodyItem {
     var title: String? { get }
     var titleFont: UIFont? { get }
     var text: [String] { get }

--- a/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
+++ b/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
@@ -1,12 +1,17 @@
 import UIKit
 
 @MainActor
-public protocol ButtonViewModel {
+public protocol ButtonViewModel: ScreenBodyItem {
     var title: GDSLocalisedString { get }
     var icon: ButtonIconViewModel? { get }
     var shouldLoadOnTap: Bool { get }
     var action: () -> Void { get }
     var accessibilityHint: GDSLocalisedString? { get }
+    var overrideContentAlignment: UIControl.ContentHorizontalAlignment { get }
+}
+
+extension ButtonViewModel {
+    public var overrideContentAlignment: UIControl.ContentHorizontalAlignment { .center }
 }
 
 public protocol ColoredButtonViewModel: ButtonViewModel {

--- a/Sources/GDSCommon/Components/ScreenBodyItem.swift
+++ b/Sources/GDSCommon/Components/ScreenBodyItem.swift
@@ -1,0 +1,1 @@
+public protocol ScreenBodyItem { }

--- a/Sources/GDSCommon/Patterns/GDSError/ErrorScreenImage.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/ErrorScreenImage.swift
@@ -1,0 +1,23 @@
+public enum ErrorScreenImage {
+    case error
+    case warning
+    case appUpdate
+    
+    var icon: String {
+        switch self {
+        case .error, .warning:
+            "exclamationmark.circle"
+        case .appUpdate:
+            "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90"
+        }
+    }
+    
+    var voiceoverPrefix: String {
+        switch self {
+        case .error, .appUpdate:
+            NSLocalizedString(key: "GDSCommonVoiceOverErrorPrefix", bundle: .module)
+        case .warning:
+            NSLocalizedString(key: "GDSCommonVoiceOverWarningPrefix", bundle: .module)
+        }
+    }
+}

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
@@ -49,8 +49,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
     private lazy var scrollViewInnerStackView: UIStackView = {
         let result = UIStackView(
             views: [
-                imageView,
-                titleLabel,
+                scrollViewIconTitleStackView,
                 bodyContentStackView
             ],
             spacing: defaultSpacing,
@@ -60,18 +59,27 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         return result
     }()
     
+    private lazy var scrollViewIconTitleStackView: UIStackView = {
+        let result = UIStackView(
+            views: [
+                imageView,
+                titleLabel
+            ],
+            spacing: defaultSpacing,
+            distribution: .equalSpacing
+        )
+        result.accessibilityIdentifier = "error-screen-icon-title-stack-view"
+        result.shouldGroupAccessibilityChildren = true
+        result.accessibilityTraits = [.header]
+        result.isAccessibilityElement = true
+        result.accessibilityLabel = "\(viewModel.image.voiceoverPrefix): \(viewModel.title) :"
+        return result
+    }()
+    
     private lazy var bottomSpacer: UIView = {
         let result = UIView()
         result.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         return result
-    }()
-    
-    private let defautlIcon = "exclamationmark.circle"
-    private lazy var voiceOverPrefix: String = {
-        guard let prefix = viewModel.voiceOverPrefix else {
-            return NSLocalizedString(key: "GDSCommonVoiceOverErrorPrefix", bundle: .module)
-        }
-        return prefix
     }()
     
     private lazy var imageView: UIImageView = {
@@ -80,7 +88,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
         
         result.image = UIImage(
-            systemName: viewModel.image ?? defautlIcon,
+            systemName: viewModel.image.icon,
             withConfiguration: configuration
         )
         result.tintColor = .gdsPrimary
@@ -102,9 +110,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         )
         result.text = viewModel.title.value
         result.accessibilityIdentifier = "error-screen-title"
-        result.accessibilityTraits = [.header]
         result.adjustsFontForContentSizeCategory = true
-        result.accessibilityLabel = "\(voiceOverPrefix): \(viewModel.title) :"
         result.textAlignment = .center
         result.numberOfLines = 0
         return result
@@ -188,7 +194,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         result.accessibilityIdentifier = "error-screen-button-\(index)"
         
         if !isPrimaryButton {
-            result.titleLabel?.textColor = .gdsGreen
+            result.titleLabel?.textColor = .accent
         }
         
         result.addAction {
@@ -234,9 +240,9 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         
         if let buttonViewModel = contentItem as? ButtonViewModel {
             let result = SecondaryButton()
-            result.setTitle(buttonViewModel.title, for: .normal)
             result.contentHorizontalAlignment = buttonViewModel.overrideContentAlignment
-            result.titleLabel?.textColor = .gdsGreen
+            result.setTitle(buttonViewModel.title, for: .normal)
+            result.titleLabel?.textColor = .accent
             result.symbolPosition = buttonViewModel.icon?.symbolPosition ?? .afterTitle
             result.icon = buttonViewModel.icon?.iconName
             result.accessibilityHint = buttonViewModel.accessibilityHint?.value
@@ -250,7 +256,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
             let result = UILabel()
             result.font = UIFont(
                 style: .body,
-                weight:  bodyTextViewModel.fontWeight
+                weight: bodyTextViewModel.fontWeight
             )
             result.text = bodyTextViewModel.text
             result.adjustsFontForContentSizeCategory = true

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
@@ -1,0 +1,230 @@
+import UIKit
+
+public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
+    
+    public private(set) var viewModel: GDSErrorViewModelV3
+        
+    let defaultSpacing = 16.0 // Use Design system when available
+    
+    private lazy var containerStackView: UIStackView = {
+        let result = UIStackView(
+            views: [
+                scrollView,
+                bottomStackView
+            ],
+            distribution: .fill
+        )
+        result.accessibilityIdentifier = "error-screen-container-stack-view"
+        return result
+    }()
+    
+    private lazy var scrollView: UIScrollView = {
+        let result = UIScrollView()
+        result.contentLayoutGuide.widthAnchor.constraint(equalTo: result.widthAnchor).isActive = true
+        result.addSubview(scrollViewOuterStackView)
+        result.accessibilityIdentifier = "error-screen-container-scrollview"
+        scrollViewOuterStackView.bindToSuperviewEdges()
+        return result
+    }()
+    
+    private lazy var scrollViewOuterStackView: UIStackView = {
+        let result = UIStackView(
+            views: [
+                topSpacer,
+                scrollViewInnerStackView,
+                bottomSpacer
+            ],
+            distribution: .equalSpacing
+        )
+        result.accessibilityIdentifier = "error-screen-outer-stack-view"
+        return result
+    }()
+    
+    private lazy var topSpacer: UIView = {
+        let result = UIView()
+        result.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        return result
+    }()
+    
+    private lazy var scrollViewInnerStackView: UIStackView = {
+        let result = UIStackView(
+            views: [
+                imageView,
+                titleLabel,
+                bodyLabel
+            ],
+            spacing: defaultSpacing,
+            distribution: .equalSpacing
+        )
+        
+        if let childView = viewModel.childView {
+            childView.accessibilityIdentifier = "error-screen-child-view"
+            result.addArrangedSubview(childView)
+        }
+        result.accessibilityIdentifier = "error-screen-inner-stack-view"
+        return result
+    }()
+    
+    private lazy var bottomSpacer: UIView = {
+        let result = UIView()
+        result.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        return result
+    }()
+    
+    private let defautlIcon = "exclamationmark.circle"
+    private lazy var voiceOverPrefix: String = {
+        guard let prefix = viewModel.voiceOverPrefix else {
+            return NSLocalizedString(key: "GDSCommonVoiceOverErrorPrefix", bundle: .module)
+        }
+        return prefix
+    }()
+    
+    private lazy var imageView: UIImageView = {
+        let result = UIImageView()
+        let font = UIFont(style: .largeTitle, weight: .regular)
+        let configuration = UIImage.SymbolConfiguration(font: font, scale: .large)
+        
+        result.image = UIImage(
+            systemName: viewModel.image ?? defautlIcon,
+            withConfiguration: configuration
+        )
+        result.tintColor = .gdsPrimary
+        result.contentMode = .scaleAspectFit
+        result.adjustsImageSizeForAccessibilityContentSizeCategory = true
+        NSLayoutConstraint.activate([
+            result.heightAnchor.constraint(greaterThanOrEqualToConstant: 107)
+        ])
+        result.accessibilityIdentifier = "error-screen-image"
+        return result
+    }()
+    
+    lazy var titleLabel: UILabel = {
+        let result = UILabel()
+        result.font = UIFont(
+            style: .largeTitle,
+            weight: .bold,
+            design: .default
+        )
+        result.text = viewModel.title.value
+        result.accessibilityIdentifier = "error-screen-title"
+        result.accessibilityTraits = [.header]
+        result.adjustsFontForContentSizeCategory = true
+        result.accessibilityLabel = "\(voiceOverPrefix): \(viewModel.title) :"
+        result.textAlignment = .center
+        result.numberOfLines = 0
+        return result
+    }()
+    
+    private lazy var bodyLabel: UILabel = {
+        let result = UILabel()
+        if let bodyContent = viewModel.body {
+            result.text = bodyContent.value
+        } else {
+            result.isHidden = true
+        }
+        result.font = UIFont(style: .body)
+        result.adjustsFontForContentSizeCategory = true
+        result.accessibilityIdentifier = "error-screen-body"
+        result.textAlignment = .center
+        result.lineBreakMode = .byTruncatingTail
+        result.numberOfLines = 0
+        return result
+    }()
+    
+    private lazy var bottomStackView: UIStackView = {
+        let hasButtons = !viewModel.buttonViewModels.isEmpty
+        let result = UIStackView(
+            views: [
+                buttonStackView
+            ],
+            spacing: defaultSpacing,
+            distribution: hasButtons ? .fillProportionally : .equalCentering
+        )
+        result.accessibilityIdentifier = "error-screen-bottom-stack-view"
+        return result
+    }()
+    
+    private lazy var buttonStackView: UIStackView = {
+        let result = UIStackView(
+            views: buttonViews,
+            spacing: defaultSpacing
+        )
+        result.axis = .vertical
+        result.spacing = defaultSpacing
+        result.accessibilityIdentifier = "error-screen-button-stack-view"
+        return result
+    }()
+    
+    private var buttonViews: [UIView] {
+        var views: [UIView] = []
+        for (index, buttonViewModel) in viewModel.buttonViewModels.enumerated() {
+            views.append(buttonForButtonViewModel(
+                buttonViewModel,
+                index
+            ))
+        }
+        return views
+    }
+    
+    public init(
+        viewModel: GDSErrorViewModelV3
+    ) {
+        self.viewModel = viewModel
+        super.init(
+            viewModel: viewModel as? BaseViewModel,
+            nibName: nil,
+            bundle: Bundle.module
+        )
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+    
+    private func buttonForButtonViewModel(
+        _ buttonViewModel: ButtonViewModel,
+        _ index: Int
+    ) -> UIButton {
+        let isPrimaryButton = index == 0
+        let result = isPrimaryButton ? RoundedButton() : SecondaryButton()
+        
+        result.setTitle(buttonViewModel.title.value, for: .normal)
+        result.accessibilityHint = buttonViewModel.accessibilityHint?.value
+        if let icon = buttonViewModel.icon {
+            result.symbolPosition = icon.symbolPosition
+            result.icon = icon.iconName
+        }
+        
+        result.accessibilityIdentifier = "error-screen-button-\(index)"
+        
+        if !isPrimaryButton {
+            result.titleLabel?.textColor = .gdsGreen
+        }
+        
+        result.addAction {
+            buttonViewModel.action()
+        }
+        return result
+    }
+    
+    private func setup() {
+        self.view.addSubview(containerStackView)
+        containerStackView.bindToSuperviewSafeArea(
+            insetBy: UIEdgeInsets(
+                top: 0,
+                left: defaultSpacing,
+                bottom: 0,
+                right: defaultSpacing
+            )
+        )
+        self.view.backgroundColor = .systemBackground
+        addRelativeViewConstraints()
+    }
+    
+    private func addRelativeViewConstraints() {
+        scrollViewOuterStackView.heightAnchor.constraint(
+            greaterThanOrEqualTo: scrollView.heightAnchor
+        ).isActive = true
+    }
+}

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@available(*, deprecated, message: "Update errors to use new DesignSystem GDSErrorScreen with GDSErrorViewModelV3") // Deprecated 24/03/2025
 private struct ErrorViewModelInitialiser: GDSErrorViewModel {
     let image: String
     let title: GDSLocalisedString
@@ -27,6 +28,7 @@ private struct ErrorViewModelInitialiser: GDSErrorViewModel {
 ///     - `primaryButton`  (type: ``RoundedButton`` inherits from ``SecondaryButton``)
 ///     - `secondaryButton`  (type: ``SecondaryButton`` inherits from ``UIButton``)
 ///     - `tertiaryButton` (type: ``SecondaryButton`` inherits from ``UIButton``)
+@available(*, deprecated, renamed: "GDSErrorScreen", message: "Update errors to use new DesignSystem GDSErrorScreen with GDSErrorViewModelV3") // Deprecated 24/03/2025
 public final class GDSErrorViewController: BaseViewController, TitledViewController {
     public override var nibName: String? { "GDSError" }
     

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -1,18 +1,5 @@
 import UIKit
 
-/// Deprecated alias to allow initialisation of ``GDSErrorViewController`` combining the below two protocols
-@available(*, deprecated, renamed: "GDSErrorViewModelV2", message: "Should also conform to GDSErrorViewModelWithImage if image is required")
-public typealias GDSErrorViewModel = GDSErrorViewModelV2 & GDSErrorViewModelWithImage
-
-/// Protocol for the view model required to initilise ``GDSErrorViewController``
-@MainActor
-public protocol GDSErrorViewModelV2 {
-    var title: GDSLocalisedString { get }
-    var body: GDSLocalisedString { get }
-    var primaryButtonViewModel: ButtonViewModel { get }
-    var secondaryButtonViewModel: ButtonViewModel? { get }
-}
-
 /// Protocol for the view model required to initilise ``GDSErrorScreen``
 @MainActor
 public protocol GDSErrorViewModelV3 {
@@ -22,13 +9,29 @@ public protocol GDSErrorViewModelV3 {
     var image: ErrorScreenImage { get }
 }
 
+/// Deprecated alias to allow initialisation of ``GDSErrorViewController`` combining the below two protocols
+@available(*, deprecated, renamed: "GDSErrorViewModelV2", message: "Should also conform to GDSErrorViewModelWithImage if image is required")
+public typealias GDSErrorViewModel = GDSErrorViewModelV2 & GDSErrorViewModelWithImage
+
+/// Protocol for the view model required to initilise ``GDSErrorViewController``
+@available(*, deprecated, renamed: "GDSErrorViewModelV3", message: "Update errors to use new DesignSystem GDSErrorScreen with GDSErrorViewModelV3") // Deprecated 24/03/2025
+@MainActor
+public protocol GDSErrorViewModelV2 {
+    var title: GDSLocalisedString { get }
+    var body: GDSLocalisedString { get }
+    var primaryButtonViewModel: ButtonViewModel { get }
+    var secondaryButtonViewModel: ButtonViewModel? { get }
+}
+
 /// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a image icon
 @MainActor
+@available(*, deprecated, message: "Update errors to use new DesignSystem GDSErrorScreen with GDSErrorViewModelV3") // Deprecated 24/03/2025
 public protocol GDSErrorViewModelWithImage {
     var image: String { get }
 }
 
 /// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a tertiary button
+@available(*, deprecated, message: "Update errors to use new DesignSystem GDSErrorScreen with GDSErrorViewModelV3") // Deprecated 24/03/2025
 @MainActor
 public protocol GDSScreenWithTertiaryButtonViewModel {
     var tertiaryButtonViewModel: ButtonViewModel { get }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -19,8 +19,7 @@ public protocol GDSErrorViewModelV3 {
     var title: GDSLocalisedString { get }
     var bodyContent: [ScreenBodyItem] { get }
     var buttonViewModels: [ButtonViewModel] { get }
-    var image: String? { get }
-    var voiceOverPrefix: String? { get }
+    var image: ErrorScreenImage { get }
 }
 
 /// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a image icon

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -17,8 +17,7 @@ public protocol GDSErrorViewModelV2 {
 @MainActor
 public protocol GDSErrorViewModelV3 {
     var title: GDSLocalisedString { get }
-    var body: GDSLocalisedString? { get }
-    var childView: UIView? { get }
+    var bodyContent: [ScreenBodyItem] { get }
     var buttonViewModels: [ButtonViewModel] { get }
     var image: String? { get }
     var voiceOverPrefix: String? { get }

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorViewModel.swift
@@ -13,6 +13,17 @@ public protocol GDSErrorViewModelV2 {
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
 
+/// Protocol for the view model required to initilise ``GDSErrorScreen``
+@MainActor
+public protocol GDSErrorViewModelV3 {
+    var title: GDSLocalisedString { get }
+    var body: GDSLocalisedString? { get }
+    var childView: UIView? { get }
+    var buttonViewModels: [ButtonViewModel] { get }
+    var image: String? { get }
+    var voiceOverPrefix: String? { get }
+}
+
 /// Conform view models that inherit from ``GDSErrorViewModelV2`` to this protocol to set a image icon
 @MainActor
 public protocol GDSErrorViewModelWithImage {

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -29,9 +29,9 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             bottomStack.accessibilityIdentifier = "centre-aligned-screen-bottom-stack-view"
         }
     }
-
+    
     internal var isFootnoteInScrollView = false
- 
+    
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
@@ -46,10 +46,10 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
         // if bottom stack covers more than 1/3 of screen
         if bottomStackHeight >= screenHeight / 3,
            !(isFootnoteInScrollView) {
-                moveFootnoteToScrollView()
+            moveFootnoteToScrollView()
         } else if (bottomStackHeight + footnoteHeight) < screenHeight / 3,
                   isFootnoteInScrollView {
-                moveFootnoteToBottomStackView()
+            moveFootnoteToBottomStackView()
         }
     }
     
@@ -131,7 +131,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             bodyLabel.accessibilityIdentifier = "centre-aligned-screen-body"
         }
     }
-
+    
     /// Stack View: `UIStackView`. Any `UIView` which is on the `GDSInformationViewModelWithChildView` view model's `childView` property.
     /// This will be added to the `stackView` below the existing `bodyLabel`
     @IBOutlet private var stackView: UIStackView! {
@@ -161,7 +161,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
     @IBOutlet private var primaryButton: RoundedButton! {
         didSet {
             if let buttonViewModel = viewModel as? GDSInformationViewModelWithOptionalPrimaryButton,
-                let button = buttonViewModel.primaryButtonViewModel {
+               let button = buttonViewModel.primaryButtonViewModel {
                 primaryButton.setTitle(button.title.value, for: .normal)
             } else if let buttonViewModel = viewModel as? GDSCentreAlignedViewModelWithPrimaryButton {
                 primaryButton.setTitle(buttonViewModel.primaryButtonViewModel.title.value, for: .normal)
@@ -211,7 +211,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             secondaryButton.accessibilityIdentifier = "centre-aligned-screen-secondary-button"
         }
     }
-
+    
     @IBAction private func secondaryButtonAction(_ sender: Any) {
         if let buttonViewModel = viewModel as? GDSInformationViewModelWithOptionalSecondaryButton {
             buttonViewModel.secondaryButtonViewModel?.action()

--- a/Sources/GDSCommon/Patterns/README.md
+++ b/Sources/GDSCommon/Patterns/README.md
@@ -243,17 +243,19 @@ This screen includes an title, subtitle and button. These views a situated withi
 The content on the screen is set from the `viewModel`, which must conform to the `OptionViewModel` protocol.
 
 
-## GDSError
-This screen is typically used as an error screen, consisting of an optional alert icon, a title, body and the option of one, two or three buttons.
-A `UIStackView` holds the `errorImageView` and encases a second `UIStackView` which holds the `errorTitle` and `errorBody`. These views are placed within a `ScrollView`.
-The `primaryButton`, `secondaryButton` and `tertiaryButton` are placed in a `UIStackView`, below the `ScrollView`.
+## GDSErrorScreen
+This screen is typically used as an error screen, consisting of an alert icon, a title, body and the option of no, one, two or three buttons.
+A container `UIStackView` holds the `scrollView` and the `bottomStackView`.
 
-`GDSErrorViewController` inherits from `BaseViewController`, so a navigation back button and right bar button can be configured. If this screen should be presented as a modal view, this should be done at the call site.
+The `bottomStackView` holds a nested `UIStackView` which contains the action buttons. 
+
+The `ScrollView` contains another `UIStackView` containing spacers and another `UIStackView` containing the Icon (`imageView`) and title (`titleLabel`), and another `UIStackView` to contain the array of body content views generate from the `[ScreenBodyItem]` array passed into the view model.
+
+`GDSErrorScreen` inherits from `BaseViewController`, so a navigation back button and right bar button can be configured. If this screen should be presented as a modal view, this should be done at the call site.
 
 A navigation item can be configured:
-- The `primaryButton`'s action is set from the ``primaryButtonViewModel`` in the ``GDSErrorViewModel`` protocol.
-- The `secondaryButton`'s action is set from the ``secondaryButtonViewModel`` in the ``GDSErrorViewModel`` protocol.
-- The `tertiaryButton`'s action is set from the ``tertiaryButtonViewModel` in the ``GDSTertiaryButtonViewModel`` protocol.
+- An array of `ButtonViewModel` passed into the view model `GDSErrorViewModelV3`, then presents either none, one, two three buttons. 
+- The first in the array is always treated as the `PrimaryButton` and all others as `SecondaryButton`
 
 If the viewModel conforms to BaseViewModel:
 - A back button can be set via the `hideBackButton` boolean property on the view controller
@@ -264,25 +266,38 @@ If the viewModel conforms to BaseViewModel:
 ### Example:
 
 ```swift
-struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
-    let image: String? = "exclamationmark.circle"
+struct MockErrorViewModelV3: GDSErrorViewModelV3, BaseViewModel {
+    var image: ErrorScreenImage = .error
     let title: GDSLocalisedString = "This is an Error View title"
-    let body: GDSLocalisedString = "This is an Error View body This is an Error View body"
-    let primaryButtonViewModel: ButtonViewModel 
-    let secondaryButtonViewModel: ButtonViewModel? = nil
-    let rightBarButtonTitle: GDSLocalisedString?
+    let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = false
     
-    init(action: @escaping () -> Void) {
-        self.primaryButtonViewModel = ButtonViewModel(titleKey: "Try again") { 
-            action() 
-        } 
-    }
+    var bodyContent: [ScreenBodyItem] = [
+        BodyTextViewModel(
+            text: "Body single line (regular)"
+        ),
+        BodyTextViewModel(
+        text:
+        """
+            Body multiple paragraphs - Lorem ipsum dolor sit amet consectetur.
+            
+            Purus aliquam mattis vitae enim mauris vestibulum massa tellus.
+        """
+        ),
+        MockButtonViewModel.textCentered
+    ]
+    
+    var buttonViewModels: [any ButtonViewModel] = [
+        MockButtonViewModel.primary,
+        MockButtonViewModel.secondary
+    ]
     
     func didAppear() {}
-    
     func didDismiss() {}
 }
+
+
+
 ```
 
 

--- a/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
+++ b/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
@@ -21,3 +21,14 @@ extension TitledViewController {
         titleLabel
     }
 }
+
+@MainActor
+protocol TitledViewControllerV2: VoiceOverFocus {
+    var titleLabel: UILabel { get }
+}
+
+extension TitledViewControllerV2 {
+    public var initialVoiceOverView: UIView {
+        titleLabel
+    }
+}

--- a/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
@@ -1,3 +1,4 @@
 // MARK: Generic Strings
 "GDSCommonBackButton" = "Yn ôl";
 "GDSCommonVoiceOverErrorPrefix" = "Gwall";
+"GDSCommonVoiceOverWarningPrefix" = "Rhybudd";

--- a/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
@@ -1,2 +1,3 @@
 // MARK: Generic Strings
 "GDSCommonBackButton" = "Yn ôl";
+"GDSCommonVoiceOverErrorPrefix" = "Gwall";

--- a/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
@@ -1,2 +1,3 @@
 // MARK: Generic Strings
 "GDSCommonBackButton" = "Back";
+"GDSCommonVoiceOverErrorPrefix" = "Error";

--- a/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
@@ -1,3 +1,4 @@
 // MARK: Generic Strings
 "GDSCommonBackButton" = "Back";
 "GDSCommonVoiceOverErrorPrefix" = "Error";
+"GDSCommonVoiceOverWarningPrefix" = "Warning";

--- a/Sources/GDSCommon/Utilities/Extensions/UIKit/UIControl+Extensions.swift
+++ b/Sources/GDSCommon/Utilities/Extensions/UIKit/UIControl+Extensions.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UIKit
+
+public extension UIControl {
+    func addAction(
+        for controlEvents: UIControl.Event = .primaryActionTriggered,
+        action: @escaping () -> Void
+    ) {
+        let sleeve = UIControl.ClosureSleeve(
+            attached: action,
+            to: self
+        )
+        
+        addTarget(
+            sleeve,
+            action: #selector(UIControl.ClosureSleeve.invoke),
+            for: controlEvents
+        )
+    }
+    
+    class ClosureSleeve {
+        let closure: () -> Void
+        init(
+            attached closure: @escaping () -> Void,
+            to object: AnyObject
+        ) {
+            self.closure = closure
+            objc_setAssociatedObject(
+                object,
+                "[\(UInt64.random(in: 0..<UInt64.max))]",
+                self,
+                .OBJC_ASSOCIATION_RETAIN
+            )
+        }
+        
+        @objc
+        func invoke() {
+            closure()
+        }
+    }
+}

--- a/Sources/GDSCommon/Utilities/Extensions/UIKit/UIStackView+Extensions.swift
+++ b/Sources/GDSCommon/Utilities/Extensions/UIKit/UIStackView+Extensions.swift
@@ -1,13 +1,29 @@
 import UIKit
 
 extension UIStackView {
-    public convenience init(views: UIView...,
-                            axis: NSLayoutConstraint.Axis = .vertical,
-                            spacing: CGFloat = 24,
-                            alignment: UIStackView.Alignment = .leading) {
+    public convenience init(
+        views: UIView...,
+        axis: NSLayoutConstraint.Axis = .vertical,
+        spacing: CGFloat = 24,
+        alignment: UIStackView.Alignment = .leading
+    ) {
         self.init(arrangedSubviews: views)
         self.axis = axis
         self.spacing = spacing
         self.alignment = alignment
+    }
+    
+    public convenience init(
+        views: [UIView],
+        axis: NSLayoutConstraint.Axis = .vertical,
+        spacing: CGFloat = 24,
+        alignment: UIStackView.Alignment = .fill,
+        distribution: UIStackView.Distribution = .fillEqually
+    ) {
+        self.init(arrangedSubviews: views)
+        self.axis = axis
+        self.spacing = spacing
+        self.alignment = alignment
+        self.distribution = distribution
     }
 }

--- a/Sources/GDSCommon/Utilities/Extensions/UIKit/UIView+Extensions.swift
+++ b/Sources/GDSCommon/Utilities/Extensions/UIKit/UIView+Extensions.swift
@@ -1,14 +1,90 @@
 import UIKit
 
 extension UIView {
-    public func addSubview(_ view: UIView, insetBy insets: UIEdgeInsets) {
+    public func addSubview(
+        _ view: UIView,
+        insetBy insets: UIEdgeInsets
+    ) {
         addSubview(view)
         view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: insets.top),
-            view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: insets.left),
-            view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -insets.right),
-            view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -insets.bottom)
+            view.topAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.topAnchor,
+                constant: insets.top
+            ),
+            view.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: insets.left
+            ),
+            view.trailingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.trailingAnchor,
+                constant: -insets.right
+            ),
+            view.bottomAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.bottomAnchor,
+                constant: -insets.bottom
+            )
         ])
+    }
+    
+    public func bindToSuperviewEdges(
+        padding: CGFloat = 0
+    ) {
+        guard let superview = self.superview else {
+            print("Error! `superview` was nil, call `addSubview(view: UIView)` before calling `bindToSuperviewEdges()` to fix this.")
+            return
+        }
+        
+        self.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            self.leadingAnchor.constraint(
+                equalTo: superview.leadingAnchor,
+                constant: padding
+            ),
+            self.trailingAnchor.constraint(
+                equalTo: superview.trailingAnchor,
+                constant: -padding
+            ),
+            self.topAnchor.constraint(
+                equalTo: superview.topAnchor,
+                constant: padding
+            ),
+            self.bottomAnchor.constraint(
+                equalTo: superview.bottomAnchor,
+                constant: -padding
+            )
+        ])
+    }
+    
+    public func bindToSuperviewSafeArea(
+        insetBy insets: UIEdgeInsets
+    ) {
+        guard let superview = self.superview else {
+            print("Error! `superview` was nil, call `addSubview(view: UIView)` before calling `bindToSuperviewSafeArea()` to fix this.")
+            return
+        }
+        
+        self.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            self.leadingAnchor.constraint(
+                equalTo: superview.safeAreaLayoutGuide.leadingAnchor,
+                constant: insets.left
+            ),
+            self.trailingAnchor.constraint(
+                equalTo: superview.safeAreaLayoutGuide.trailingAnchor,
+                constant: -insets.right
+            ),
+            self.topAnchor.constraint(
+                equalTo: superview.safeAreaLayoutGuide.topAnchor,
+                constant: insets.top
+            ),
+            self.bottomAnchor.constraint(
+                equalTo: superview.safeAreaLayoutGuide.bottomAnchor,
+                constant: -insets.bottom
+            )
+        ])
+        
     }
 }

--- a/Tests/GDSCommonTests/ButtonViewModelTests.swift
+++ b/Tests/GDSCommonTests/ButtonViewModelTests.swift
@@ -36,6 +36,7 @@ struct TestButtonViewModel: ButtonViewModel {
     let title: GDSLocalisedString
     let icon: ButtonIconViewModel? = nil
     let shouldLoadOnTap: Bool = false
+    var contentAlignment: UIControl.ContentHorizontalAlignment? = .center
     let action: () -> Void
     let accessibilityHint: GDSLocalisedString?
 }

--- a/Tests/GDSCommonTests/ComponentTests/Mocks/MockButtonViewModel.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Mocks/MockButtonViewModel.swift
@@ -1,12 +1,20 @@
 import GDSCommon
+import UIKit
 
 internal struct MockButtonViewModel: ButtonViewModel {
     let title: GDSLocalisedString
     let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
+    var contentAlignment: UIControl.ContentHorizontalAlignment?
     let action: () -> Void
     
-    init(title: GDSLocalisedString, icon: ButtonIconViewModel? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void) {
+    init(
+        title: GDSLocalisedString,
+        icon: ButtonIconViewModel? = nil,
+        shouldLoadOnTap: Bool = false,
+        contentAlignment: UIControl.ContentHorizontalAlignment? = .center,
+        action: @escaping () -> Void
+    ) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap


### PR DESCRIPTION
# _New Error Pattern Error Screen_

This PR adds a new code only generated screen to match requirements for the new Error screen pattern.
https://govukverify.atlassian.net/browse/DCMAW-11848

### Screen Demos

https://github.com/user-attachments/assets/deba362e-e5b0-42b0-942e-4d89f5187c84

### VoiceOver Example


https://github.com/user-attachments/assets/af9e909f-7368-4b39-b2a6-170b469bf6ff


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
