### PR TITLE
feat: adding accessibility hint to modal info buttons

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ErrorScreenTests.swift
@@ -30,7 +30,7 @@ final class GDSErrorScreenTests: XCTestCase {
             title: "Primary Action",
             icon: nil,
             shouldLoadOnTap: false,
-            voiceOverHint: "Button hint",
+            accessibilityHint: "Button hint",
             action: {
                 self.didTap_primaryButton = true
             }
@@ -39,7 +39,7 @@ final class GDSErrorScreenTests: XCTestCase {
             title: "Secondary Action",
             icon: MockButtonIconViewModel(),
             shouldLoadOnTap: false,
-            voiceOverHint: "Button hint",
+            accessibilityHint: "Button hint",
             action: {
                 self.didTap_secondaryButton = true
             }
@@ -49,7 +49,7 @@ final class GDSErrorScreenTests: XCTestCase {
             title: "Tertiary Action",
             icon: MockButtonIconViewModel(),
             shouldLoadOnTap: false,
-            voiceOverHint: "Button hint",
+            accessibilityHint: "Button hint",
             action: {
                 self.didTap_tertiaryButton = true
             }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -17,7 +17,7 @@ final class GDSCentreAlignedScreenTests: XCTestCase {
         super.setUp()
         
         primaryButtonViewModel = MockButtonViewModel(title: "Primary button title",
-                                                     voiceOverHint: "Centre aligned screen accessibility hint") {
+                                                     accessibilityHint: "Centre aligned screen accessibility hint") {
             self.didTap_primaryButton = true
         }
         

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -184,7 +184,7 @@ struct MockButtonViewModel: ButtonViewModel {
         title: GDSLocalisedString,
         icon: ButtonIconViewModel? = nil,
         shouldLoadOnTap: Bool = false,
-        voiceOverHint: GDSLocalisedString? = nil,
+        accessibilityHint: GDSLocalisedString? = nil,
         contentAlignment: UIControl.ContentHorizontalAlignment? = .center,
         action: @escaping () -> Void
     ) {
@@ -192,7 +192,7 @@ struct MockButtonViewModel: ButtonViewModel {
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
         self.action = action
-        self.accessibilityHint = voiceOverHint
+        self.accessibilityHint = accessibilityHint
         self.contentAlignment = contentAlignment
     }
 }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -36,6 +36,7 @@ extension ModalInfoViewControllerTests {
     @MainActor
     func test_modalInfoViewButtons() throws {
         viewModel = MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel(title: "Primary button",
+                                                                                              accessibilityHint: "This includes an accessibility hint",
                                                                                               action: { self.primaryButton = true }),
                                                   secondaryButtonViewModel: MockButtonViewModel(title: "Secondary button",
                                                                                                 icon: MockButtonIconViewModel(),
@@ -46,8 +47,10 @@ extension ModalInfoViewControllerTests {
         sut = ModalInfoViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button")
+        XCTAssertEqual(try sut.primaryButton.accessibilityHint, "This includes an accessibility hint")
         XCTAssertNil((try sut.primaryButton as? RoundedButton)?.icon)
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary button")
+        XCTAssertNil(try sut.secondaryButton.accessibilityHint)
         XCTAssertTrue(sut.isModalInPresentation)
         
         XCTAssertFalse(primaryButton)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/ModalInfoViewControllerTests.swift
@@ -36,21 +36,22 @@ extension ModalInfoViewControllerTests {
     @MainActor
     func test_modalInfoViewButtons() throws {
         viewModel = MockModalInfoButtonsViewModel(primaryButtonViewModel: MockButtonViewModel(title: "Primary button",
-                                                                                              accessibilityHint: "This includes an accessibility hint",
                                                                                               action: { self.primaryButton = true }),
                                                   secondaryButtonViewModel: MockButtonViewModel(title: "Secondary button",
                                                                                                 icon: MockButtonIconViewModel(),
                                                                                                 action: { self.secondaryButton = true }),
                                                   textButtonViewModel: MockButtonViewModel(title: "Text button",
+                                                                                           accessibilityHint: "This includes an accessibility hint",
                                                                                            action: {self.textButton = true }))
         
         sut = ModalInfoViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button")
-        XCTAssertEqual(try sut.primaryButton.accessibilityHint, "This includes an accessibility hint")
+        XCTAssertNil(try sut.primaryButton.accessibilityHint)
         XCTAssertNil((try sut.primaryButton as? RoundedButton)?.icon)
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary button")
         XCTAssertNil(try sut.secondaryButton.accessibilityHint)
+        XCTAssertEqual(try sut.textButton.accessibilityHint, "This includes an accessibility hint")
         XCTAssertTrue(sut.isModalInPresentation)
         
         XCTAssertFalse(primaryButton)

--- a/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -97,6 +97,7 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
             if let vm = viewModel as? PageWithTextButtonViewModel {
                 textButton.setTitle(vm.textButtonViewModel.title, for: .normal)
                 textButton.accessibilityIdentifier = "modal-info-text-button"
+                textButton.accessibilityHint = vm.textButtonViewModel.accessibilityHint?.value
             } else {
                 textButton.isHidden = true
             }

--- a/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewController.swift
+++ b/Sources/GDSCommon/Patterns/ModalInfoView/ModalInfoViewController.swift
@@ -55,6 +55,7 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
             if let pbvm = viewModel as? PageWithPrimaryButtonViewModel {
                 primaryButton.setTitle(pbvm.primaryButtonViewModel.title, for: .normal)
                 primaryButton.accessibilityIdentifier = "modal-info-primary-button"
+                primaryButton.accessibilityHint = pbvm.primaryButtonViewModel.accessibilityHint?.value
                 if let icon = pbvm.primaryButtonViewModel.icon {
                     primaryButton.symbolPosition = icon.symbolPosition
                     primaryButton.icon = icon.iconName
@@ -76,6 +77,7 @@ public final class ModalInfoViewController: BaseViewController, TitledViewContro
             if let sbvm = viewModel as? PageWithSecondaryButtonViewModel {
                 secondaryButton.setTitle(sbvm.secondaryButtonViewModel.title, for: .normal)
                 secondaryButton.accessibilityIdentifier = "modal-info-secondary-button"
+                secondaryButton.accessibilityHint = sbvm.secondaryButtonViewModel.accessibilityHint?.value
                 if let icon = sbvm.secondaryButtonViewModel.icon {
                     secondaryButton.symbolPosition = icon.symbolPosition
                     secondaryButton.icon = icon.iconName


### PR DESCRIPTION
# DCMAW-12205: Adding accessibility hint to modal info buttons

Following a missed requirement in [DCMAW-7383](https://govukverify.atlassian.net/browse/DCMAW-7873), this PR aims to add accessibility hints to the buttons on the `ModalInfoViewController`.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    ~- [ ] Checked dynamic type sizes are applied~
    - [x] Checked VoiceOver can navigate your new code
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`


[DCMAW-7383]: https://govukverify.atlassian.net/browse/DCMAW-7383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ