### PR TITLE
fix: updating screen body item protocol and body text item

### DIFF
--- a/Sources/GDSCommon/Components/BodyTextViewModel.swift
+++ b/Sources/GDSCommon/Components/BodyTextViewModel.swift
@@ -1,17 +1,33 @@
 import UIKit
 
 public struct BodyTextViewModel: ScreenBodyItem {
-    var text: String
+    var text: GDSLocalisedString
     var fontWeight: UIFont.Weight
     var overridingAlignment: NSTextAlignment?
     
     public init(
-        text: String,
+        text: GDSLocalisedString,
         fontWeight: UIFont.Weight = .regular,
         overridingAlignment: NSTextAlignment? = nil
     ) {
         self.text = text
         self.fontWeight = fontWeight
         self.overridingAlignment = overridingAlignment
+    }
+}
+
+extension BodyTextViewModel {
+    public var uiView: UIView {
+        let result = UILabel()
+        result.font = UIFont(
+            style: .body,
+            weight: self.fontWeight
+        )
+        result.text = self.text.value
+        result.adjustsFontForContentSizeCategory = true
+        result.lineBreakMode = .byTruncatingTail
+        result.textAlignment = .center
+        result.numberOfLines = 0
+        return result
     }
 }

--- a/Sources/GDSCommon/Components/BodyTextViewModel.swift
+++ b/Sources/GDSCommon/Components/BodyTextViewModel.swift
@@ -25,7 +25,7 @@ extension BodyTextViewModel {
         )
         result.text = self.text.value
         result.adjustsFontForContentSizeCategory = true
-        result.lineBreakMode = .byTruncatingTail
+        result.lineBreakMode = .byWordWrapping
         result.textAlignment = .center
         result.numberOfLines = 0
         return result

--- a/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
+++ b/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
@@ -7,3 +7,17 @@ public protocol BulletViewModel: ScreenBodyItem {
     var titleFont: UIFont? { get }
     var text: [String] { get }
 }
+
+extension BulletViewModel {
+    public var uiView: UIView {
+        let result = BulletView(
+            title: self.title,
+            text: self.text,
+            titleFont: self.titleFont ?? UIFont(
+                style: .title2,
+                weight: .bold
+            )
+        )
+        return result
+    }
+}

--- a/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
+++ b/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
@@ -13,10 +13,7 @@ extension BulletViewModel {
         let result = BulletView(
             title: self.title,
             text: self.text,
-            titleFont: self.titleFont ?? UIFont(
-                style: .title2,
-                weight: .bold
-            )
+            titleFont: self.titleFont ?? .title3Bold
         )
         return result
     }

--- a/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
+++ b/Sources/GDSCommon/Components/Buttons/ButtonViewModel.swift
@@ -14,6 +14,23 @@ extension ButtonViewModel {
     public var overrideContentAlignment: UIControl.ContentHorizontalAlignment { .center }
 }
 
+extension ButtonViewModel {
+    public var uiView: UIView {
+        let result = SecondaryButton()
+        result.contentHorizontalAlignment = self.overrideContentAlignment
+        result.setTitle(self.title, for: .normal)
+        result.titleLabel?.textColor = .accent
+        result.symbolPosition = self.icon?.symbolPosition ?? .afterTitle
+        result.icon = self.icon?.iconName
+        result.accessibilityHint = self.accessibilityHint?.value
+        result.addAction {
+            self.action()
+        }
+        return result
+    }
+}
+
+
 public protocol ColoredButtonViewModel: ButtonViewModel {
     var backgroundColor: UIColor { get }
 }

--- a/Sources/GDSCommon/Components/ScreenBodyItem.swift
+++ b/Sources/GDSCommon/Components/ScreenBodyItem.swift
@@ -1,1 +1,5 @@
-public protocol ScreenBodyItem { }
+import UIKit
+
+public protocol ScreenBodyItem {
+    @MainActor var uiView: UIView { get }
+}

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
@@ -228,57 +228,9 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         result.append(
             contentsOf:
                 viewModel.bodyContent.compactMap { screenBodyItem in
-                    createViewForBodyContentItem(screenBodyItem)
+                    screenBodyItem.uiView
                 }
         )
         return result
     }()
-    
-    private func createViewForBodyContentItem(
-        _ contentItem: ScreenBodyItem
-    ) -> UIView? {
-        
-        if let buttonViewModel = contentItem as? ButtonViewModel {
-            let result = SecondaryButton()
-            result.contentHorizontalAlignment = buttonViewModel.overrideContentAlignment
-            result.setTitle(buttonViewModel.title, for: .normal)
-            result.titleLabel?.textColor = .accent
-            result.symbolPosition = buttonViewModel.icon?.symbolPosition ?? .afterTitle
-            result.icon = buttonViewModel.icon?.iconName
-            result.accessibilityHint = buttonViewModel.accessibilityHint?.value
-            result.addAction {
-                buttonViewModel.action()
-            }
-            return result
-        }
-        
-        if let bodyTextViewModel = contentItem as? BodyTextViewModel {
-            let result = UILabel()
-            result.font = UIFont(
-                style: .body,
-                weight: bodyTextViewModel.fontWeight
-            )
-            result.text = bodyTextViewModel.text
-            result.adjustsFontForContentSizeCategory = true
-            result.lineBreakMode = .byTruncatingTail
-            result.textAlignment = .center
-            result.numberOfLines = 0
-            return result
-        }
-        
-        if let bulletViewModel = contentItem as? BulletViewModel {
-            let result = BulletView(
-                title: bulletViewModel.title,
-                text: bulletViewModel.text,
-                titleFont: bulletViewModel.titleFont ?? UIFont(
-                    style: .title2,
-                    weight: .bold
-                )
-            )
-            return result
-        }
-        
-        return nil
-    }
-    
 }

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -58,6 +58,13 @@ extension BulletViewTests {
         try XCTAssertEqual(sut.titleLabel.text, "Title")
         try XCTAssertEqual(sut.titleLabel.font, .init(style: .title3, weight: .semibold))
     }
+    
+    @MainActor
+    func test_viewModelIsScreenBodyItem() async throws {
+        let viewModel = MockBulletViewModel(title: "title", text: ["item 1", "item 2", "item 3"])
+        XCTAssert(viewModel.uiView is BulletView)
+        let view = try XCTUnwrap(viewModel.uiView as? BulletView)
+    }
 }
 
 extension BulletView {

--- a/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/BulletViewTests.swift
@@ -61,7 +61,7 @@ extension BulletViewTests {
     
     @MainActor
     func test_viewModelIsScreenBodyItem() async throws {
-        let viewModel = MockBulletViewModel(title: "title", text: ["item 1", "item 2", "item 3"])
+        let viewModel = MockBulletViewModel()
         XCTAssert(viewModel.uiView is BulletView)
         let view = try XCTUnwrap(viewModel.uiView as? BulletView)
     }

--- a/Tests/GDSCommonTests/ComponentTests/Image+ExtensionsTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Image+ExtensionsTests.swift
@@ -5,7 +5,10 @@ import XCTest
 final class ImageExtensionsTests: XCTestCase {
     func test_iconImage() throws {
         let sut = Image(systemName: "sun.min")
-        XCTAssertEqual(try sut.iconImage().inspect().implicitAnyView().image().font(), Font.body.weight(.light))
+        XCTAssertEqual(
+            try sut.iconImage().inspect().implicitAnyView().image().font(),
+            Font.body.weight(.light)
+        )
         XCTAssertEqual(try sut.iconImage().inspect().implicitAnyView().image().isScaledToFit(), true)
         XCTAssertEqual(try sut.iconImage().inspect().implicitAnyView().image().imageScale(), .large)
     }

--- a/Tests/GDSCommonTests/ComponentTests/Mocks/MockBulletViewModel.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Mocks/MockBulletViewModel.swift
@@ -3,7 +3,7 @@ import UIKit
 
 @MainActor
 struct MockBulletViewModel: BulletViewModel {
-    var title: String? = "test title"
-    var titleFont: UIFont? = .title3
-    var text = ["item 1", "item 2", "item 3"]
+    let title: String? = "test title"
+    var titleFont: UIFont?
+    let text = ["item 1", "item 2", "item 3"]
 }

--- a/Tests/GDSCommonTests/ComponentTests/Mocks/MockBulletViewModel.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Mocks/MockBulletViewModel.swift
@@ -1,0 +1,9 @@
+import GDSCommon
+import UIKit
+
+@MainActor
+struct MockBulletViewModel: BulletViewModel {
+    var title: String? = "test title"
+    var titleFont: UIFont? = .title3
+    var text = ["item 1", "item 2", "item 3"]
+}

--- a/Tests/GDSCommonTests/ScreenBodyItemTests.swift
+++ b/Tests/GDSCommonTests/ScreenBodyItemTests.swift
@@ -15,6 +15,7 @@ struct ScreenBodyItemTests {
         #expect(label?.numberOfLines == 0)
     }
     
+    @Test
     func bulletViewModel() throws {
         let viewModel = MockBulletViewModel()
         let view = viewModel.uiView as? BulletView
@@ -24,16 +25,10 @@ struct ScreenBodyItemTests {
         #expect(bulletLabels.map(\.text) == ["item 1", "item 2", "item 3"])
     }
     
+    @Test
     func buttonViewModel() {
         let viewModel = MockButtonViewModel(title: "button title", action: {})
         let view = viewModel.uiView as? UIButton
         #expect(view?.titleLabel?.text == "button title")
     }
-}
-
-@MainActor
-struct MockBulletViewModel: BulletViewModel {
-    var title: String? = "test title"
-    var titleFont: UIFont? = .title3
-    var text = ["item 1", "item 2", "item 3"]
 }

--- a/Tests/GDSCommonTests/ScreenBodyItemTests.swift
+++ b/Tests/GDSCommonTests/ScreenBodyItemTests.swift
@@ -3,7 +3,7 @@ import Testing
 import UIKit
 
 @MainActor
-struct SScreenBodyItemTests {
+struct ScreenBodyItemTests {
     @Test
     func bodyTextViewModel() {
         let viewModel = BodyTextViewModel(text: "Test text")
@@ -18,9 +18,10 @@ struct SScreenBodyItemTests {
     func bulletViewModel() throws {
         let viewModel = MockBulletViewModel()
         let view = viewModel.uiView as? BulletView
+        #expect(viewModel.uiView is BulletView)
         #expect(view?.titleLabel.text == "test title")
         let bulletLabels: [UILabel] = try view?.bulletLabels as? [UILabel] ?? []
-        #expect(view?.bulletLabels.map(\.text) == ["item 1", "item 2", "item 3"])
+        #expect(bulletLabels.map(\.text) == ["item 1", "item 2", "item 3"])
     }
     
     func buttonViewModel() {

--- a/Tests/GDSCommonTests/ScreenBodyItemTests.swift
+++ b/Tests/GDSCommonTests/ScreenBodyItemTests.swift
@@ -1,0 +1,38 @@
+import GDSCommon
+import Testing
+import UIKit
+
+@MainActor
+struct SScreenBodyItemTests {
+    @Test
+    func bodyTextViewModel() {
+        let viewModel = BodyTextViewModel(text: "Test text")
+        let label = viewModel.uiView as? UILabel
+        #expect(label?.text == "Test text")
+        #expect(label?.font == UIFont.body)
+        #expect(label?.textAlignment == .center)
+        #expect(label?.lineBreakMode == .byWordWrapping)
+        #expect(label?.numberOfLines == 0)
+    }
+    
+    func bulletViewModel() throws {
+        let viewModel = MockBulletViewModel()
+        let view = viewModel.uiView as? BulletView
+        #expect(view?.titleLabel.text == "test title")
+        let bulletLabels: [UILabel] = try view?.bulletLabels as? [UILabel] ?? []
+        #expect(view?.bulletLabels.map(\.text) == ["item 1", "item 2", "item 3"])
+    }
+    
+    func buttonViewModel() {
+        let viewModel = MockButtonViewModel(title: "button title", action: {})
+        let view = viewModel.uiView as? UIButton
+        #expect(view?.titleLabel?.text == "button title")
+    }
+}
+
+@MainActor
+struct MockBulletViewModel: BulletViewModel {
+    var title: String? = "test title"
+    var titleFont: UIFont? = .title3
+    var text = ["item 1", "item 2", "item 3"]
+}

--- a/Tests/GDSCommonTests/ScreenBodyItemTests.swift
+++ b/Tests/GDSCommonTests/ScreenBodyItemTests.swift
@@ -22,7 +22,8 @@ struct ScreenBodyItemTests {
         #expect(viewModel.uiView is BulletView)
         #expect(view?.titleLabel.text == "test title")
         let bulletLabels: [UILabel] = try view?.bulletLabels as? [UILabel] ?? []
-        #expect(bulletLabels.map(\.text) == ["item 1", "item 2", "item 3"])
+        #expect(view?.titleLabel.font == .title3Bold)
+        #expect(bulletLabels.map(\.text) == ["\t●\titem 1", "\t●\titem 2", "\t●\titem 3"])
     }
     
     @Test


### PR DESCRIPTION
# Adjustments to the GDSErrorScreen work

### WARNING ###
************
This is technically a breaking change. Would like to merge without bumping the major version number as this is a tweak on a new feature. 
************

2 changes here:
- Changing the body text content item to use GDSLocalisedString instead of String
- Updating ScreenBodyItem protocol to have a `uiView` property to simplify its use and allow for adding of custom content items from consumer codebases



# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
