### PR TITLE
fix: fixing low contrast on button icon

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -50,7 +50,7 @@ struct MockButtonViewModelWithVoiceOverHint: ButtonViewModel {
 extension MockButtonViewModel {
     static var primary: MockButtonViewModel {
         MockButtonViewModel(title: "Action button",
-                            icon: MockButtonIconViewModel(iconName: "arrow.up.right", symbolPosition: .afterTitle),
+                            icon: MockButtonIconViewModel(iconName: "qrcode", symbolPosition: .afterTitle),
                             shouldLoadOnTap: false,
                             action: {})
     }

--- a/Sources/GDSCommon/Components/Buttons/RoundedButton.swift
+++ b/Sources/GDSCommon/Components/Buttons/RoundedButton.swift
@@ -69,11 +69,26 @@ public final class RoundedButton: SecondaryButton {
     public override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         if let nextItem = context.nextFocusedItem, nextItem.isEqual(self) {
             backgroundColor = .gdsYellow
-            setTitleColor(.black, for: .normal)
+            redrawTitle(with: .black)
         } else {
             backgroundColor = .gdsGreen
-            setTitleColor(.white, for: .normal)
+            redrawTitle(with: .white)
         }
+    }
+    
+    private func redrawTitle(with colour: UIColor) {
+        guard let icon = icon else {
+            setTitleColor(colour, for: .normal)
+            return
+        }
+        
+        let configuration = UIImage.SymbolConfiguration(font: .init(style: .body, weight: fontWeight))
+        let title = self.title(for: .normal) ?? ""
+        let textString = NSAttributedString(string: title,
+                                            attributes: [.font: UIFont(style: .body, weight: fontWeight)])
+            .addingSymbol(named: icon, configuration: configuration, tintColor: colour, symbolPosition: symbolPosition)
+        setTitleColor(colour, for: .normal)
+        setAttributedTitle(textString, for: .normal)
     }
     
     public override func accessibilityElementDidBecomeFocused() {


### PR DESCRIPTION
#  fix: fixing low contrast on button icon

_Thank you for your contribution to the project._

When using a keyboard, the scan QR code icon has low colour contrast in hover state. The expected behaviour is that content should be legible whatever state the UI is in and the icon image should match text colour.
This is under the SC 1.4.13 content on hover and 1.4.3 colour contrast of the WCAG success criteria and they are both level AA issues.

The change here ensures that when we hover over the primary button with an icon, we see the icon as the same colour as the text.

Before:

https://github.com/user-attachments/assets/e8af3c7a-643a-466d-be60-5c8412bbe460


After:

https://github.com/user-attachments/assets/1964a3f8-4c8e-4e92-9171-6cdb0ec34c99


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
