### PR TITLE
fix: button title label colour fix

### DIFF
--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
@@ -198,7 +198,7 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         result.accessibilityIdentifier = "error-screen-button-\(index)"
         
         if !isPrimaryButton {
-            result.titleLabel?.textColor = .accent
+            result.setTitleColor(.accent, for: .normal)
         }
         
         result.addAction {

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -234,7 +234,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             }
         }
         
-        result.titleLabel?.textColor = .gdsGreen
+        result.setTitleColor(.accent, for: .normal)
         result.isUserInteractionEnabled = true
         return result
     }()


### PR DESCRIPTION
# Setting button title colours correctly

Previously two button title label colours were set:
`button.titleLabel?.textColor = <some colour>`

It should be set:
`button.setTitleColor(<some colour>, for: .normal)`

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
