### PR TITLE
fix: conditionally adding bottom stack view subviews

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSCentreAlignedViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSCentreAlignedViewModel.swift
@@ -39,3 +39,16 @@ struct MockGDSCentreAlignedViewModel: GDSCentreAlignedViewModel,
         return stackView
     }
 }
+
+
+struct MockGDSCentreAlignedViewModelNoButtons: GDSCentreAlignedViewModel,
+                                      BaseViewModel {
+    let title: GDSLocalisedString = "This is a centre aligned screen title"
+    let body: GDSLocalisedString? = "This is an optional centre aligned screen body. This screen has no buttons"
+    let rightBarButtonTitle: GDSLocalisedString? = "Dismiss"
+    let backButtonIsHidden: Bool = false
+    
+    func didAppear() {}
+    
+    func didDismiss() {}
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -41,6 +41,7 @@ enum Screens: String, CaseIterable {
     case gdsInformationView = "Information View - Deprecated"
     case gdsInformationViewV2 = "Information View V2 - Deprecated"
     case gdsCentreAlignedScreen = "Centre Aligned Screen"
+    case gdsCentreAlignedScreenNoButtons = "Centre Aligned Screen (no buttons)"
     case gdsLoadingView = "GDS Loading View"
     
     var isModal: Bool {
@@ -154,6 +155,8 @@ enum Screens: String, CaseIterable {
             return GDSInformationViewController(viewModel: MockGDSInformationViewModelV2())
         case .gdsCentreAlignedScreen:
             return GDSCentreAlignedScreen(viewModel: MockGDSCentreAlignedViewModel())
+        case .gdsCentreAlignedScreenNoButtons:
+            return GDSCentreAlignedScreen(viewModel: MockGDSCentreAlignedViewModelNoButtons())
         case .gdsLoadingView:
             return GDSLoadingViewController()
         

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -335,32 +335,30 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
     }
     
     private func moveFootnoteToScrollView() {
-        if let footnoteLabel {
-            if footnoteLabel.superview == bottomStackView {
-                // remove footnote from bottom stack
-                bottomStackView.removeArrangedSubview(footnoteLabel)
-                footnoteLabel.removeFromSuperview()
-                isFootnoteInScrollView = true
-                
-                // add to scroll view
-                scrollViewInnerStackView.addArrangedSubview(footnoteLabel)
-                footnoteLabel.translatesAutoresizingMaskIntoConstraints = false
-            }
+        if let footnoteLabel,
+           footnoteLabel.superview == bottomStackView {
+            // remove footnote from bottom stack
+            bottomStackView.removeArrangedSubview(footnoteLabel)
+            footnoteLabel.removeFromSuperview()
+            isFootnoteInScrollView = true
+            
+            // add to scroll view
+            scrollViewInnerStackView.addArrangedSubview(footnoteLabel)
+            footnoteLabel.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     
     private func moveFootnoteToBottomStackView() {
-        if let footnoteLabel {
-            if  footnoteLabel.superview != bottomStackView {
-                // remove from scroll view
-                scrollViewInnerStackView.removeArrangedSubview(footnoteLabel)
-                footnoteLabel.removeFromSuperview()
-                isFootnoteInScrollView = false
-                
-                // add to stack
-                bottomStackView.insertArrangedSubview(footnoteLabel, at: 0)
-                view.layoutIfNeeded()
-            }
+        if let footnoteLabel,
+           footnoteLabel.superview != bottomStackView {
+            // remove from scroll view
+            scrollViewInnerStackView.removeArrangedSubview(footnoteLabel)
+            footnoteLabel.removeFromSuperview()
+            isFootnoteInScrollView = false
+            
+            // add to stack
+            bottomStackView.insertArrangedSubview(footnoteLabel, at: 0)
+            view.layoutIfNeeded()
         }
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -49,11 +49,14 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
     private lazy var containerStackView: UIStackView = {
         let result = UIStackView(
             views: [
-                scrollView,
-                bottomStackView
+                scrollView
             ],
             distribution: .fill
         )
+        
+        if !bottomStackView.subviews.isEmpty {
+            result.addArrangedSubview(bottomStackView)
+        }
         result.accessibilityIdentifier = "centre-aligned-screen-container-stack-view"
         return result
     }()
@@ -143,13 +146,22 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
     
     private lazy var bottomStackView: UIStackView = {
         let result = UIStackView(
-            views: [
-                footnoteLabel,
-                primaryButton,
-                secondaryButton
-            ],
+            views: [],
             spacing: defaultSpacing
         )
+        
+        if viewModel is GDSCentreAlignedViewModelWithFootnote {
+            result.addArrangedSubview(footnoteLabel)
+        }
+        
+        if viewModel is GDSCentreAlignedViewModelWithPrimaryButton {
+            result.addArrangedSubview(primaryButton)
+        }
+        
+        if viewModel is GDSCentreAlignedViewModelWithSecondaryButton {
+            result.addArrangedSubview(secondaryButton)
+        }
+
         result.accessibilityIdentifier = "centre-aligned-screen-bottom-stack-view"
         return result
     }()

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -150,15 +150,21 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             spacing: defaultSpacing
         )
         
-        if viewModel is GDSCentreAlignedViewModelWithFootnote {
+        if viewModel is GDSCentreAlignedViewModelWithFootnote ||
+            viewModel is GDSInformationViewModelWithFootnote ||
+            viewModel is GDSInformationViewModel {
             result.addArrangedSubview(footnoteLabel)
         }
         
-        if viewModel is GDSCentreAlignedViewModelWithPrimaryButton {
+        if viewModel is GDSCentreAlignedViewModelWithPrimaryButton ||
+            viewModel is GDSInformationViewModelWithOptionalPrimaryButton ||
+            viewModel is GDSInformationViewModel {
             result.addArrangedSubview(primaryButton)
         }
         
-        if viewModel is GDSCentreAlignedViewModelWithSecondaryButton {
+        if viewModel is GDSCentreAlignedViewModelWithSecondaryButton ||
+            viewModel is GDSInformationViewModelWithSecondaryButton ||
+            viewModel is GDSInformationViewModel {
             result.addArrangedSubview(secondaryButton)
         }
 


### PR DESCRIPTION
# Fixing layout issue when bottom stack views are empty

When the bottom stack wasn't needed, 3 empty views were being added to it. This caused problems with layout as those views expanded to occupy a lot of screen space, preventing the title from being vertically centred.

This PR makes the bottom stack sub-views optional and only adding them to the stack if they are needed.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
