### PR TITLE
feat: adding voiceover to introView image

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockIntroViewModel.swift
@@ -8,6 +8,7 @@ struct MockIntroViewModel: IntroViewModel, BaseViewModel {
     let introButtonViewModel: ButtonViewModel
     let rightBarButtonTitle: GDSLocalisedString?
     let backButtonIsHidden: Bool = false
+    let accessibilityLabel: GDSLocalisedString? = "Intro Screen"
     
     func didAppear() { }
     func didDismiss() { }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/IntroViewControllerTests.swift
@@ -69,6 +69,7 @@ extension IntroViewControllerTests {
     @MainActor
     func test_labelContents() throws {
         XCTAssertNotNil(try sut.introImage)
+        XCTAssertEqual(sut.accessibilityLabel, viewModel.accessibilityLabel?.value)
         XCTAssertEqual(try sut.titleLabel.text, "Intro screen title")
         XCTAssertEqual(try sut.titleLabel.font, .largeTitleBold)
         XCTAssertTrue(try sut.titleLabel.accessibilityTraits.contains(.header))

--- a/Sources/GDSCommon/Patterns/IntroView/IntroViewController.swift
+++ b/Sources/GDSCommon/Patterns/IntroView/IntroViewController.swift
@@ -28,6 +28,9 @@ public final class IntroViewController: BaseViewController, TitledViewController
     @IBOutlet private var introImage: UIImageView! {
         didSet {
             introImage.image = viewModel.image
+            introImage.isAccessibilityElement = true
+            introImage.accessibilityLabel = viewModel.accessibilityLabel?.value
+            introImage.accessibilityTraits = .image
             introImage.accessibilityIdentifier = "intro-image"
         }
     }

--- a/Sources/GDSCommon/Patterns/IntroView/IntroViewModel.swift
+++ b/Sources/GDSCommon/Patterns/IntroView/IntroViewModel.swift
@@ -7,4 +7,9 @@ public protocol IntroViewModel {
     var title: GDSLocalisedString { get }
     var body: GDSLocalisedString { get }
     var introButtonViewModel: ButtonViewModel { get }
+    var accessibilityLabel: GDSLocalisedString? { get }
+}
+
+extension IntroViewModel {
+    public var accessibilityLabel: GDSLocalisedString? { nil }
 }


### PR DESCRIPTION
# DCMAW-12973: adding voiceover to introView image

One of the requirements for [12973](https://govukverify.atlassian.net/browse/DCMAW-12973) is to announce the intro screen image for the OneLogin app. This involves making the proposed changes in this repo to identify the image as an accessibility element.

https://github.com/user-attachments/assets/3310c8f2-af9b-443c-a461-61de098081b3


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
