### PR TITLE
fix: button loading logic

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -94,7 +94,7 @@ extension MockButtonViewModel {
     static var withVoiceoverHint: MockButtonViewModelWithVoiceOverHint {
         MockButtonViewModelWithVoiceOverHint(title: "Primary Button",
                                              icon: nil,
-                                             shouldLoadOnTap: false,
+                                             shouldLoadOnTap: true,
                                              action: { },
                                              accessibilityHint: "This includes a voiceover hint")
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -93,6 +93,48 @@ extension GDSCentreAlignedScreenTests {
         XCTAssertFalse(sut.isFootnoteInScrollView)
     }
     
+    func test_primaryButtonLoadsOnTap() throws {
+        primaryButtonViewModel = MockButtonViewModel(title: "Primary button with icon",
+                                                     icon: MockButtonIconViewModel(),
+                                                     shouldLoadOnTap: true) {}
+        viewModel = MockGDSCentreAlignedViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                  secondaryButtonViewModel: secondaryButtonViewModel) {
+            // empty implementation
+        } dismissAction: {
+            // empty implementation
+        }
+        sut = GDSCentreAlignedScreen(viewModel: viewModel)
+        
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(try sut.primaryButton.isLoading)
+    }
+    
+    func test_primaryButtonLoadsOnTap_resetsOnViewAppear() throws {
+        primaryButtonViewModel = MockButtonViewModel(title: "Primary button with icon",
+                                                     icon: MockButtonIconViewModel(),
+                                                     shouldLoadOnTap: true) {}
+        viewModel = MockGDSCentreAlignedViewModel(primaryButtonViewModel: primaryButtonViewModel,
+                                                  secondaryButtonViewModel: secondaryButtonViewModel) {
+            // empty implementation
+        } dismissAction: {
+            // empty implementation
+        }
+        sut = GDSCentreAlignedScreen(viewModel: viewModel)
+        
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(try sut.primaryButton.isLoading)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
+
+        sut.viewDidAppear(true)
+        XCTAssertFalse(try sut.primaryButton.isLoading)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+    }
+    
+    func test_primaryButtonDoesNotLoadOnTap() throws {
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertFalse(try sut.primaryButton.isLoading)
+    }
+    
     func test_primaryButtonNoIcon() throws {
         XCTAssertNil(try sut.primaryButton.icon)
     }

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSErrorScreenTests.swift
@@ -29,7 +29,7 @@ final class GDSErrorScreenTests: XCTestCase {
         let primaryButtonViewModel = MockButtonViewModel(
             title: "Primary Action",
             icon: nil,
-            shouldLoadOnTap: false,
+            shouldLoadOnTap: true,
             accessibilityHint: "Button hint",
             action: {
                 self.didTap_primaryButton = true
@@ -152,7 +152,11 @@ extension GDSErrorScreenTests {
     
     func test_primaryButtonAction() throws {
         XCTAssertFalse(didTap_primaryButton)
+        XCTAssertFalse(try sut.primaryButton.isLoading)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
         try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(try sut.primaryButton.isLoading)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
         XCTAssertTrue(didTap_primaryButton)
     }
     

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSLeftAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSLeftAlignedScreenTests.swift
@@ -28,7 +28,7 @@ final class GDSLeftAlignedScreenTests: XCTestCase {
         let primaryButtonViewModel = MockButtonViewModel(
             title: "Primary Action",
             icon: nil,
-            shouldLoadOnTap: false,
+            shouldLoadOnTap: true,
             accessibilityHint: "Button hint",
             action: {
                 self.didTap_primaryButton = true
@@ -146,7 +146,11 @@ extension GDSLeftAlignedScreenTests {
     
     func test_primaryButtonAction() throws {
         XCTAssertFalse(didTap_primaryButton)
+        XCTAssertFalse(try sut.primaryButton.isLoading)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
         try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(try sut.primaryButton.isLoading)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
         XCTAssertTrue(didTap_primaryButton)
     }
     

--- a/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSError/GDSErrorScreen.swift
@@ -203,6 +203,10 @@ public class GDSErrorScreen: BaseViewController, TitledViewControllerV2 {
         }
         
         result.addAction {
+            if let result = result as? RoundedButton {
+                result.isLoading = buttonViewModel.shouldLoadOnTap
+                result.isEnabled = false
+            }
             buttonViewModel.action()
         }
         return result

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -223,11 +223,18 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
             result.accessibilityIdentifier = "centre-aligned-screen-primary-button"
             result.addAction { [unowned self] in
                 if let buttonViewModel = viewModel as? GDSCentreAlignedViewModelWithPrimaryButton {
+                    primaryButton?.isLoading = buttonViewModel.primaryButtonViewModel.shouldLoadOnTap
+                    primaryButton?.isEnabled = false
                     buttonViewModel.primaryButtonViewModel.action()
                 }
             }
             return result
     }()
+    
+    public func resetPrimaryButton() {
+        primaryButton?.isLoading = false
+        primaryButton?.isEnabled = true
+    }
     
     private lazy var secondaryButton: SecondaryButton? = {
         guard viewModel is GDSCentreAlignedViewModelWithSecondaryButton ||
@@ -309,6 +316,11 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
     public override func viewDidLoad() {
         super.viewDidLoad()
         setup()
+    }
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        resetPrimaryButton()
     }
     
     @available(*, unavailable, renamed: "init(viewModel:)")

--- a/Sources/GDSCommon/Patterns/GDSLeftAligned/GDSLeftAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSLeftAligned/GDSLeftAlignedScreen.swift
@@ -201,6 +201,10 @@ public class GDSLeftAlignedScreen: BaseViewController, TitledViewControllerV2 {
         }
         
         result.addAction {
+            if let result = result as? RoundedButton {
+                result.isLoading = buttonViewModel.shouldLoadOnTap
+                result.isEnabled = false
+            }
             buttonViewModel.action()
         }
         return result


### PR DESCRIPTION
# fix: button loading logic

_Thank you for your contribution to the project._

The logic for having a loading animator on the button in the centre aligned view was missing, this PR adds it and also a public function to reset the button should we need to in the cases of a modal popover from the button event being subsequently dismissed.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
