### PR TITLE
fix: enables primary button when returning to GDSInstructionsViewController

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -162,7 +162,8 @@ extension GDSInstructionsViewControllerTests {
         let buttonViewModel = MockButtonViewModel(title: GDSLocalisedString(stringLiteral: "button title")) {
             self.didTapButton = true
         }
-        viewModel = MockGDSInstructionsViewModelPrimaryButtonState(childView: bulletView,
+        viewModel = MockGDSInstructionsViewModelPrimaryButtonState(shouldDisablePrimaryButtonAfterTap: false,
+                                                                   childView: bulletView,
                                                                    buttonViewModel: buttonViewModel,
                                                                    secondaryButtonViewModel: nil,
                                                                    screenView: { }) {
@@ -173,6 +174,25 @@ extension GDSInstructionsViewControllerTests {
         XCTAssertTrue(try sut.primaryButton.isEnabled)
         try sut.primaryButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(try sut.primaryButton.isEnabled)
+    }
+
+    @MainActor
+    func test_primaryButtonActionDisabled() throws {
+        let buttonViewModel = MockButtonViewModel(title: GDSLocalisedString(stringLiteral: "button title")) {
+            self.didTapButton = true
+        }
+        viewModel = MockGDSInstructionsViewModelPrimaryButtonState(shouldDisablePrimaryButtonAfterTap: true,
+                                                                   childView: bulletView,
+                                                                   buttonViewModel: buttonViewModel,
+                                                                   secondaryButtonViewModel: nil,
+                                                                   screenView: { }) {
+            self.didTapButton = true
+        }
+        sut = GDSInstructionsViewController(viewModel: viewModel)
+        XCTAssertNotNil(try sut.primaryButton)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
     }
 }
 

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -156,6 +156,24 @@ extension GDSInstructionsViewControllerTests {
         sut.resetPrimaryButton()
         XCTAssertTrue(try sut.primaryButton.isEnabled)
     }
+
+    @MainActor
+    func test_primaryButtonActionRemainsEnabled() throws {
+        let buttonViewModel = MockButtonViewModel(title: GDSLocalisedString(stringLiteral: "button title")) {
+            self.didTapButton = true
+        }
+        viewModel = MockGDSInstructionsViewModelPrimaryButtonState(childView: bulletView,
+                                                                   buttonViewModel: buttonViewModel,
+                                                                   secondaryButtonViewModel: nil,
+                                                                   screenView: { }) {
+            self.didTapButton = true
+        }
+        sut = GDSInstructionsViewController(viewModel: viewModel)
+        XCTAssertNotNil(try sut.primaryButton)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+    }
 }
 
 

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -146,6 +146,16 @@ extension GDSInstructionsViewControllerTests {
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "button title")
         XCTAssertNotEqual(try sut.secondaryButton.backgroundColor, .gdsGreen)
     }
+
+    @MainActor
+    func test_resetPrimaryButton() throws {
+        XCTAssertNotNil(try sut.primaryButton)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
+        sut.resetPrimaryButton()
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+    }
 }
 
 

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -115,10 +115,19 @@ extension GDSInstructionsViewControllerTests {
     @MainActor
     func test_primaryButton() throws {
         XCTAssertNotNil(try sut.primaryButton)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "button title")
         XCTAssertEqual(try sut.primaryButton.backgroundColor, .gdsGreen)
     }
-    
+
+    @MainActor
+    func test_primaryButtonAction() throws {
+        XCTAssertNotNil(try sut.primaryButton)
+        XCTAssertTrue(try sut.primaryButton.isEnabled)
+        try sut.primaryButton.sendActions(for: .touchUpInside)
+        XCTAssertFalse(try sut.primaryButton.isEnabled)
+    }
+
     @MainActor
     func test_coloredButton() throws {
         let coloredButton = MockColoredButtonViewModel(title: "Test", action: { }, backgroundColor: .gdsRed)

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInstructionsViewModel.swift
@@ -21,3 +21,27 @@ internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseView
         dismissAction()
     }
 }
+
+internal struct MockGDSInstructionsViewModelPrimaryButtonState: GDSInstructionsViewModel,
+                                                                GDSInstructionsViewModelPrimaryButtonState,
+                                                                BaseViewModel {
+    let shouldDisablePrimaryButtonAfterTap: Bool = false
+    let title: GDSLocalisedString = "test title"
+    let body: String = "test body"
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
+    let childView: UIView
+    let buttonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel?
+    let backButtonIsHidden: Bool = false
+
+    let screenView: () -> Void
+    let dismissAction: () -> Void
+
+    func didAppear() {
+        screenView()
+    }
+
+    func didDismiss() {
+        dismissAction()
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/Mocks/MockGDSInstructionsViewModel.swift
@@ -25,7 +25,7 @@ internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel, BaseView
 internal struct MockGDSInstructionsViewModelPrimaryButtonState: GDSInstructionsViewModel,
                                                                 GDSInstructionsViewModelPrimaryButtonState,
                                                                 BaseViewModel {
-    let shouldDisablePrimaryButtonAfterTap: Bool = false
+    let shouldDisablePrimaryButtonAfterTap: Bool
     let title: GDSLocalisedString = "test title"
     let body: String = "test body"
     let rightBarButtonTitle: GDSLocalisedString? = "right bar button"

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -109,7 +109,7 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
         if let viewModel = viewModel as? GDSInstructionsViewModelPrimaryButtonState {
-            primaryButton.isEnabled = viewModel.shouldDisablePrimaryButtonAfterTap
+            primaryButton.isEnabled = !viewModel.shouldDisablePrimaryButtonAfterTap
         } else {
             primaryButton.isEnabled = false
         }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -41,7 +41,12 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
     }
-    
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        resetPrimaryButton()
+    }
+
     /// Title label: `UILabel`
     @IBOutlet private(set) var titleLabel: UILabel! {
         didSet {
@@ -103,9 +108,8 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
-        if let viewModel = viewModel as? GDSInstructionsViewModelEnablePrimaryButton {
-            primaryButton.isEnabled = viewModel.shouldEnableOnTap
-            resetPrimaryButton()
+        if let viewModel = viewModel as? GDSInstructionsViewModelKeepPrimaryButtonEnabled {
+            primaryButton.isEnabled = viewModel.shouldKeepEnabled
         } else {
             primaryButton.isEnabled = false
         }
@@ -119,8 +123,8 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     }
 
     public func resetPrimaryButton() {
-        if let viewModel = viewModel as? GDSInstructionsViewModelEnablePrimaryButton {
-            primaryButton.isEnabled = viewModel.shouldEnableOnTap
+        if let viewModel = viewModel as? GDSInstructionsViewModelKeepPrimaryButtonEnabled {
+            primaryButton.isEnabled = true
         }
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -38,7 +38,6 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.resetPrimaryButton()
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
     }
@@ -104,15 +103,10 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
-        primaryButton.isEnabled = false
-        if let viewModel = viewModel as? GDSInstructionsViewModelDisableButton {
-            primaryButton.isEnabled = false
-        } else {
-            self.resetPrimaryButton()
-        }
+        resetPrimaryButton()
         viewModel.buttonViewModel.action()
     }
-    
+
     @IBAction private func didTapSecondaryButton() {
         if let buttonViewModel = viewModel.secondaryButtonViewModel {
             buttonViewModel.action()
@@ -120,6 +114,8 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     }
 
     private func resetPrimaryButton() {
-        primaryButton.isEnabled = true
+        if let viewModel = viewModel as? GDSInstructionsViewModelDisableButton {
+            primaryButton.isEnabled = viewModel.shouldEnableOnTap
+        }
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -108,8 +108,8 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
-        if let viewModel = viewModel as? GDSInstructionsViewModelKeepPrimaryButtonEnabled {
-            primaryButton.isEnabled = viewModel.shouldKeepEnabled
+        if let viewModel = viewModel as? GDSInstructionsViewModelPrimaryButtonState {
+            primaryButton.isEnabled = viewModel.shouldDisablePrimaryButtonAfterTap
         } else {
             primaryButton.isEnabled = false
         }
@@ -123,8 +123,6 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     }
 
     public func resetPrimaryButton() {
-        if let viewModel = viewModel as? GDSInstructionsViewModelKeepPrimaryButtonEnabled {
-            primaryButton.isEnabled = true
-        }
+        primaryButton.isEnabled = true
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -38,6 +38,7 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.resetPrimaryButton()
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
     }
@@ -104,6 +105,11 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
         primaryButton.isEnabled = false
+        if let viewModel = viewModel as? GDSInstructionsViewModelDisableButton {
+            primaryButton.isEnabled = false
+        } else {
+            self.resetPrimaryButton()
+        }
         viewModel.buttonViewModel.action()
     }
     
@@ -111,5 +117,9 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
         if let buttonViewModel = viewModel.secondaryButtonViewModel {
             buttonViewModel.action()
         }
+    }
+
+    private func resetPrimaryButton() {
+        primaryButton.isEnabled = true
     }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -103,7 +103,12 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
     
     @IBAction private func didTapPrimaryButton() {
         primaryButton.isLoading = viewModel.buttonViewModel.shouldLoadOnTap
-        resetPrimaryButton()
+        if let viewModel = viewModel as? GDSInstructionsViewModelEnablePrimaryButton {
+            primaryButton.isEnabled = viewModel.shouldEnableOnTap
+            resetPrimaryButton()
+        } else {
+            primaryButton.isEnabled = false
+        }
         viewModel.buttonViewModel.action()
     }
 
@@ -113,8 +118,8 @@ public class GDSInstructionsViewController: BaseViewController, TitledViewContro
         }
     }
 
-    private func resetPrimaryButton() {
-        if let viewModel = viewModel as? GDSInstructionsViewModelDisableButton {
+    public func resetPrimaryButton() {
+        if let viewModel = viewModel as? GDSInstructionsViewModelEnablePrimaryButton {
             primaryButton.isEnabled = viewModel.shouldEnableOnTap
         }
     }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -24,6 +24,6 @@ public protocol GDSInstructionsViewModel {
 /// `true` keeps the primary button enabled
 /// `false` disables the primary button
 @MainActor
-public protocol GDSInstructionsViewModelDisableButton {
+public protocol GDSInstructionsViewModelEnablePrimaryButton {
     var shouldEnableOnTap: Bool { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -24,6 +24,6 @@ public protocol GDSInstructionsViewModel {
 /// `true` keeps the primary button enabled
 /// `false` disables the primary button
 @MainActor
-public protocol GDSInstructionsViewModelEnablePrimaryButton {
-    var shouldEnableOnTap: Bool { get }
+public protocol GDSInstructionsViewModelKeepPrimaryButtonEnabled {
+    var shouldKeepEnabled: Bool { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -20,9 +20,10 @@ public protocol GDSInstructionsViewModel {
 }
 
 /// View model for ``GDSInstructionsViewController``
-/// If conforming to this view model, the primary button remains disabled when returning to the screen
-///  otherwise, the primary button is enabled and can be tapped again
+/// setting a value to determine if the primary button should be disabled or stay enabled after tapping
+/// `true` keeps the primary button enabled
+/// `false` disables the primary button
 @MainActor
 public protocol GDSInstructionsViewModelDisableButton {
-    var shouldDisableOnTap: Bool { get }
+    var shouldEnableOnTap: Bool { get }
 }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -21,8 +21,8 @@ public protocol GDSInstructionsViewModel {
 
 /// View model for ``GDSInstructionsViewController``
 /// setting a value to determine if the primary button should be disabled or stay enabled after tapping
-/// `true` keeps the primary button enabled
-/// `false` disables the primary button
+/// `true`disables the primary button
+/// `false` keeps the primary button enabled
 @MainActor
 public protocol GDSInstructionsViewModelPrimaryButtonState {
     var shouldDisablePrimaryButtonAfterTap: Bool { get }

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -18,3 +18,11 @@ public protocol GDSInstructionsViewModel {
     var buttonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
 }
+
+/// View model for ``GDSInstructionsViewController``
+/// If conforming to this view model, the primary button remains disabled when returning to the screen
+///  otherwise, the primary button is enabled and can be tapped again
+@MainActor
+public protocol GDSInstructionsViewModelDisableButton {
+    var shouldDisableOnTap: Bool { get }
+}

--- a/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -24,6 +24,6 @@ public protocol GDSInstructionsViewModel {
 /// `true` keeps the primary button enabled
 /// `false` disables the primary button
 @MainActor
-public protocol GDSInstructionsViewModelKeepPrimaryButtonEnabled {
-    var shouldKeepEnabled: Bool { get }
+public protocol GDSInstructionsViewModelPrimaryButtonState {
+    var shouldDisablePrimaryButtonAfterTap: Bool { get }
 }


### PR DESCRIPTION
# DCMAW-12655: Button disabled when going back from abort screen

A bug was discovered in ID Check ([ticket](https://govukverify.atlassian.net/browse/DCMAW-12655)) when upon dismissing the abort flow and going back, the primary button on `GDSInstructionsViewController` was disabled. 

This PR creates a new view model, `GDSInstructionsViewModelDisableButton`, which if conformed to will disable the primary button. Otherwise, the primary button is enabled.

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
