### PR TITLE
fix: announce "card" after content tile title

### DIFF
--- a/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
+++ b/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
@@ -67,7 +67,9 @@ public final class GDSContentTileView: NibView {
             titleLabel.text = viewModel.title.value
             titleLabel.font = viewModel.titleFont
             titleLabel.accessibilityIdentifier = "content-tile-title"
-            titleLabel.accessibilityLabel = titleLabel.text?.appending(" card")
+            titleLabel.accessibilityLabel =  GDSLocalisedString(stringKey: "CardComponent",
+                                                                viewModel.title.value,
+                                                                bundle: .module).value
         }
     }
     

--- a/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
+++ b/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
@@ -67,6 +67,7 @@ public final class GDSContentTileView: NibView {
             titleLabel.text = viewModel.title.value
             titleLabel.font = viewModel.titleFont
             titleLabel.accessibilityIdentifier = "content-tile-title"
+            titleLabel.accessibilityLabel = titleLabel.text?.appending(" card")
         }
     }
     

--- a/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/cy.lproj/Localizable.strings
@@ -28,3 +28,8 @@
 "8" = "wyth";
 
 "9" = "naw";
+
+
+// MARK: Card component
+
+"CardComponent" = "Cerdyn %@";

--- a/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
+++ b/Sources/GDSCommon/Styles/Strings/en.lproj/Localizable.strings
@@ -10,3 +10,8 @@
 // MARK: Numbered List
 
 "NumberedList" = "Numbered list, %@ items.";
+
+
+// MARK: Card component
+
+"CardComponent" = "%@ Card";

--- a/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
@@ -113,7 +113,7 @@ extension GDSContentTileViewTests {
     func test_titleContents() {
         XCTAssertEqual(try sut.titleLabel.text, viewModel.title.value)
         XCTAssertEqual(try sut.titleLabel.font, .title2Bold)
-        XCTAssertEqual(try sut.titleLabel.accessibilityLabel, "Test Title card")
+        XCTAssertEqual(try sut.titleLabel.accessibilityLabel, "Test Title Card")
     }
     
     func test_bodyContents() {

--- a/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
@@ -113,6 +113,7 @@ extension GDSContentTileViewTests {
     func test_titleContents() {
         XCTAssertEqual(try sut.titleLabel.text, viewModel.title.value)
         XCTAssertEqual(try sut.titleLabel.font, .title2Bold)
+        XCTAssertEqual(try sut.titleLabel.accessibilityLabel, "Test Title card")
     }
     
     func test_bodyContents() {


### PR DESCRIPTION
# DCMAW-13646: announce "card" after content tile title

## English
https://github.com/user-attachments/assets/4a705f80-d568-465c-899d-d25a3556e65e

## Welsh
https://github.com/user-attachments/assets/4f77d3d8-1a92-4477-9c7c-fd3f10ecb41a



# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
