### PR TITLE
fix: make VoiceOverFocus protocols public

### DIFF
--- a/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
+++ b/Sources/GDSCommon/Patterns/VoiceOverFocus.swift
@@ -12,7 +12,7 @@ public protocol VoiceOverFocus {
 /// from ``BaseViewController``, conform the view controller to ``TitledViewController`` to
 /// automaticaly direct VoiceOver to the ``titleLabel`` when the screen appears
 @MainActor
-protocol TitledViewController: VoiceOverFocus {
+public protocol TitledViewController: VoiceOverFocus {
     var titleLabel: UILabel! { get }
 }
 
@@ -23,7 +23,7 @@ extension TitledViewController {
 }
 
 @MainActor
-protocol TitledViewControllerV2: VoiceOverFocus {
+public protocol TitledViewControllerV2: VoiceOverFocus {
     var titleLabel: UILabel { get }
 }
 


### PR DESCRIPTION
# Make VoiceOverFocus protocols public

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
