### PR TITLE
fix: removing gdsRed dark mode

### DIFF
--- a/Sources/GDSCommon/Styles/Colours.xcassets/Colours/Red.colorset/Contents.json
+++ b/Sources/GDSCommon/Styles/Colours.xcassets/Colours/Red.colorset/Contents.json
@@ -11,24 +11,6 @@
         }
       },
       "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x61",
-          "green" : "0x69",
-          "red" : "0xFF"
-        }
-      },
-      "idiom" : "universal"
     }
   ],
   "info" : {


### PR DESCRIPTION
# DCMAW-14124: 

#FF6961 with white text doesn't pass colour contrast, so `gdsRed` should use #D4351C for both light and dark mode. Therefore, this PR removes #FF6961 from `gdsRed`.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
