### PR TITLE
feat: tabBarController orientation locking functionality 

### DIFF
--- a/Sources/GDSCommon/Utilities/OrientationLockingTabBarController.swift
+++ b/Sources/GDSCommon/Utilities/OrientationLockingTabBarController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol OrientationLockingViewController: UIViewController {
+public protocol OrientationLockingNavigationController: UINavigationController {
     // Empty implementation
 }
 
@@ -8,7 +8,7 @@ public protocol OrientationLockingViewController: UIViewController {
 // It ensures the correct view controller handles rotation.
 public class OrientationLockingTabBarController: UITabBarController {
     override open var shouldAutorotate: Bool {
-        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingViewController {
+        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingNavigationController {
             return vc.shouldAutorotate
         } else {
             return super.shouldAutorotate
@@ -16,7 +16,7 @@ public class OrientationLockingTabBarController: UITabBarController {
     }
     
     override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingViewController {
+        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingNavigationController {
             return vc.preferredInterfaceOrientationForPresentation
         } else {
             return super.preferredInterfaceOrientationForPresentation
@@ -24,7 +24,7 @@ public class OrientationLockingTabBarController: UITabBarController {
     }
     
     override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingViewController {
+        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingNavigationController {
             return vc.supportedInterfaceOrientations
         } else {
             return super.supportedInterfaceOrientations
@@ -32,7 +32,7 @@ public class OrientationLockingTabBarController: UITabBarController {
     }
     
     override open var preferredStatusBarStyle: UIStatusBarStyle {
-        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingViewController {
+        if let vc = self.selectedViewController?.presentedViewController, vc is OrientationLockingNavigationController {
             return vc.preferredStatusBarStyle
         } else {
             return super.preferredStatusBarStyle

--- a/Tests/GDSCommonTests/OrientationLockingTabBarControllerTests.swift
+++ b/Tests/GDSCommonTests/OrientationLockingTabBarControllerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class OrientationLockingTabBarControllerTests: XCTestCase {
     private var sut: OrientationLockingTabBarController!
     private var navigationController: UINavigationController!
-    private var orientationLockingViewController: OrientationLockingViewController!
+    private var orientationLockingViewController: OrientationLockingNavigationController!
     private var viewController: UIViewController!
     
     override func setUp() {
@@ -122,7 +122,7 @@ extension OrientationLockingTabBarControllerTests {
     }
 }
 
-class MockOrientationLockingViewController: UINavigationController, OrientationLockingViewController {
+class MockOrientationLockingViewController: UINavigationController, OrientationLockingNavigationController {
     let shouldAutorotateValue: Bool
     
     init(shouldAutorotate: Bool = false) {


### PR DESCRIPTION
# DCMAW-13381: Orientation locking functionality

`UITabBarController` overrides the displaying viewController rotation preferences, this PR creates `OrientationLockingTabBarController` which ensures the correct viewController handles rotation.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
