### PR TITLE
feat: DCMAW-13401 - added more ScreenBodyItems

### DIFF
--- a/GDSCommon-Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GDSCommon-Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "788e7879d38a839c4e348ab0762dcc0364e646a2",
-        "version" : "0.10.1"
+        "revision" : "a6fcac8485bc8f57b2d2b55bb6d97138e8659e4b",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockErrorViewModel.swift
@@ -31,6 +31,19 @@ var multipleParagraph: ScreenBodyItem {
     )
 }
 
+var divider: ScreenBodyItem {
+    DividerViewModel(background: .gdsBlack)
+}
+
+@MainActor
+var bulletedList: ScreenBodyItem {
+    BaseBulletViewModel(
+        title: "Bulleted List",
+        titleFont: .title1,
+        text: ["Item 1", "Item 2", "Item 3"]
+    )
+}
+
 struct MockErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "This is an Error View title"

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSLeftAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSLeftAlignedScreenTests.swift
@@ -79,6 +79,8 @@ final class GDSLeftAlignedScreenTests: XCTestCase {
             bodyContent: [
                 singleLineRegular,
                 singleParagraph,
+                divider,
+                bulletedList,
                 MockButtonViewModel(
                     title: "Button",
                     action: {}
@@ -238,7 +240,7 @@ extension GDSLeftAlignedScreenTests {
     func test_leftAligedContentItems() throws {
         sut = createSUT()
         
-        XCTAssertEqual(try sut.bodyContentView.arrangedSubviews.count, 3)
+        XCTAssertEqual(try sut.bodyContentView.arrangedSubviews.count, 5)
         let labelContainer = try XCTUnwrap(sut.bodyContentView.arrangedSubviews[0] as? UIStackView)
         let label = try XCTUnwrap(labelContainer.arrangedSubviews[0] as? UILabel)
         XCTAssertEqual(label.text, "Body single line (regular)")
@@ -252,7 +254,7 @@ extension GDSLeftAlignedScreenTests {
             """
         )
         
-        let buttonContainer = try XCTUnwrap(sut.bodyContentView.arrangedSubviews[2] as? UIStackView)
+        let buttonContainer = try XCTUnwrap(sut.bodyContentView.arrangedSubviews[4] as? UIStackView)
         let button = try XCTUnwrap(buttonContainer.arrangedSubviews[0] as? SecondaryButton)
         XCTAssertEqual(button.titleLabel?.text, "Button")
     }

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/nalexn/ViewInspector",
-                 .upToNextMajor(from: .init(0, 10, 1)))
+                 .upToNextMajor(from: "0.10.1"))
     ],
     targets: [
         .target(name: "GDSCommon"),

--- a/Sources/GDSCommon/Components/BodyContent/BodyTextViewModel.swift
+++ b/Sources/GDSCommon/Components/BodyContent/BodyTextViewModel.swift
@@ -4,15 +4,18 @@ public struct BodyTextViewModel: ScreenBodyItem {
     var text: GDSLocalisedString
     var fontWeight: UIFont.Weight
     var overridingAlignment: NSTextAlignment?
+    var minimumHeight: CGFloat?
     
     public init(
         text: GDSLocalisedString,
         fontWeight: UIFont.Weight = .regular,
-        overridingAlignment: NSTextAlignment? = nil
+        overridingAlignment: NSTextAlignment? = nil,
+        minimumHeight: CGFloat? = nil
     ) {
         self.text = text
         self.fontWeight = fontWeight
         self.overridingAlignment = overridingAlignment
+        self.minimumHeight = minimumHeight
     }
 }
 
@@ -28,6 +31,9 @@ extension BodyTextViewModel {
         result.lineBreakMode = .byWordWrapping
         result.textAlignment = overridingAlignment ?? .center
         result.numberOfLines = 0
+        if let minimumHeight {
+            result.heightAnchor.constraint(equalToConstant: minimumHeight).isActive = true
+        }
         return result
     }
 }

--- a/Sources/GDSCommon/Components/BodyContent/DividerViewModel.swift
+++ b/Sources/GDSCommon/Components/BodyContent/DividerViewModel.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+public struct DividerViewModel: ScreenBodyItem {
+    var background: UIColor
+    
+    public init(background: UIColor) {
+        self.background = background
+    }
+}
+
+extension DividerViewModel {
+    public var uiView: UIView {
+        let result = UIView()
+        result.accessibilityIdentifier = "divider"
+        result.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        result.backgroundColor = background
+        return result
+    }
+}

--- a/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
+++ b/Sources/GDSCommon/Components/BulletView/BulletViewModel.swift
@@ -18,3 +18,19 @@ extension BulletViewModel {
         return result
     }
 }
+
+public struct BaseBulletViewModel: BulletViewModel {
+    public var title: String?
+    public var titleFont: UIFont? = .init(style: .body, weight: .bold)
+    public var text: [String]
+    
+    public init(
+        title: String? = nil,
+        titleFont: UIFont? = nil,
+        text: [String]
+    ) {
+        self.title = title
+        self.titleFont = titleFont
+        self.text = text
+    }
+}

--- a/Sources/GDSCommon/Patterns/GDSLeftAligned/GDSLeftAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSLeftAligned/GDSLeftAlignedScreen.swift
@@ -1,8 +1,16 @@
 import UIKit
 
-public class GDSLeftAlignedScreen: BaseViewController, TitledViewControllerV2 {
-    
+public class GDSLeftAlignedScreen: BaseViewController, VoiceOverFocus {
     public private(set) var viewModel: GDSLeftAlignedViewModel
+    
+    public var initialVoiceOverView: UIView {
+        if scrollViewTitleStackView.isHidden,
+           let first = viewModel.bodyContent.first {
+            return first.uiView
+        } else {
+            return titleLabel
+        }
+    }
         
     let defaultSpacing = 16.0 // Use Design system when available
     
@@ -82,6 +90,7 @@ public class GDSLeftAlignedScreen: BaseViewController, TitledViewControllerV2 {
             trailing: defaultSpacing
         )
         result.accessibilityIdentifier = "left-aligned-screen-title-stack-view"
+        result.isHidden = viewModel.title.value.isEmpty
         return result
     }()
     


### PR DESCRIPTION
# _ScreenBodyItems Additions_

Added more ScreenBodyItems to support Document information screen updates
* BodyTextViewModel (updated to add optional minimumHeight to enable alignment with other items)
* DividerViewModel (new)
* GDSLeftAlignedScreen (updated to hide titlestackview when title is empty)

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
