### PR TITLE
fix: dynamic type on title label

### DIFF
--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSCentreAlignedScreenTests.swift
@@ -247,8 +247,12 @@ extension GDSCentreAlignedScreenTests {
         sut = GDSInformationViewController(viewModel: viewModel)
         
         XCTAssertEqual(try sut.titleLabel.text, "V2 Information screen title")
+        XCTAssertTrue(try sut.titleLabel.adjustsFontForContentSizeCategory)
         XCTAssertEqual(try sut.bodyLabel.text, "V2 Information screen body")
+        XCTAssertTrue(try sut.bodyLabel.adjustsFontForContentSizeCategory)
         XCTAssertEqual(try sut.footnoteLabel.text, "V2 Information screen footnote")
+        XCTAssertTrue(try sut.footnoteLabel.adjustsFontForContentSizeCategory)
+        
         XCTAssertEqual(try sut.primaryButton.title(for: .normal), "Primary button title")
         XCTAssertEqual(try sut.secondaryButton.title(for: .normal), "Secondary button title")
     }

--- a/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
+++ b/Sources/GDSCommon/Patterns/GDSInformation/GDSCentreAlignedScreen.swift
@@ -27,6 +27,7 @@ public final class GDSCentreAlignedScreen: BaseViewController, TitledViewControl
         result.textAlignment = .center
         result.lineBreakMode = .byTruncatingTail
         result.numberOfLines = 0
+        result.adjustsFontForContentSizeCategory = true
         return result
     }()
     


### PR DESCRIPTION
# Centre Aligned Screen title dynamic type

Centre aligned screen title label incorrectly did not have dynamic type set.

https://govukverify.atlassian.net/browse/DCMAW-14082

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
