### PR TITLE
fix: ContentTileCard's primary button keyboard focus fix

### DIFF
--- a/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
+++ b/Sources/GDSCommon/Components/ContentTile/GDSContentTileView.swift
@@ -137,7 +137,8 @@ public final class GDSContentTileView: NibView {
                 )
                 primaryButton.isUserInteractionEnabled = true
                 primaryButton.accessibilityIdentifier = "content-primary-button"
-                
+                primaryButton.isAccessibilityElement = true
+
                 buttonStack.addArrangedSubview(primaryButton)
             }
         }

--- a/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
@@ -127,7 +127,7 @@ extension GDSContentTileViewTests {
     
     func test_primaryButton() throws {
         XCTAssertEqual(try sut.primaryButton.titleLabel?.text, viewModel.primaryButtonViewModel.title.value)
-        XCTAssertTrue(sut.primaryButton.isAccessibilityElement)
+        XCTAssertTrue(try sut.primaryButton.isAccessibilityElement)
 
         XCTAssertFalse(didTapPrimaryButton)
         viewModel.primaryButtonViewModel.action()

--- a/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
+++ b/Tests/GDSCommonTests/ComponentTests/GDSContentTileViewTests.swift
@@ -127,7 +127,8 @@ extension GDSContentTileViewTests {
     
     func test_primaryButton() throws {
         XCTAssertEqual(try sut.primaryButton.titleLabel?.text, viewModel.primaryButtonViewModel.title.value)
-        
+        XCTAssertTrue(sut.primaryButton.isAccessibilityElement)
+
         XCTAssertFalse(didTapPrimaryButton)
         viewModel.primaryButtonViewModel.action()
         XCTAssertTrue(didTapPrimaryButton)


### PR DESCRIPTION
# DCMAW-13478: Keyboard focus on ContentTileCard's primary button

Ticket: https://govukverify.atlassian.net/browse/DCMAW-13478

This aims to address an issue discovered with the `GDSContentTileView` primary button which could not be focused when using an external keyboard. This now allows the user to navigate with the arrow keys into the card and activate the button.

https://github.com/user-attachments/assets/963e568a-7384-4a55-a2a5-2361a27f0093 (taken from the TestWrapper ID Check app, red cell not included)

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
