### PR TITLE
fix: updated view inspector tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.app
+          sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Install and configure dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -workspace "GDSCommon-Demo.xcworkspace" -scheme GDSCommon-Demo test \
-           -destination "platform=iOS Simulator,name=iPhone 16,OS=18.0" \
+           -destination "platform=iOS Simulator,name=iPhone 16,OS=18.6" \
            -enableCodeCoverage YES \
            -resultBundlePath result.xcresult | xcbeautify
 

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
+          sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Install and configure dependencies
         run: |
@@ -33,7 +33,7 @@ jobs:
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -workspace "GDSCommon-Demo.xcworkspace" -scheme GDSCommon-Demo test \
-           -destination "platform=iOS Simulator,name=iPhone 16,OS=18.0" \
+           -destination "platform=iOS Simulator,name=iPhone 16,OS=18.6" \
            -enableCodeCoverage YES \
            -resultBundlePath result.xcresult | xcbeautify
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/nalexn/ViewInspector",
-                 .upToNextMajor(from: "0.10.1"))
+                 .upToNextMajor(from: "0.10.2"))
     ],
     targets: [
         .target(name: "GDSCommon"),

--- a/Tests/GDSCommonTests/ButtonStylesTests.swift
+++ b/Tests/GDSCommonTests/ButtonStylesTests.swift
@@ -19,15 +19,17 @@ extension ButtonStylesTests {
     func test_primaryButton() throws {
         let sut = try Primary().inspect(isPressed: false)
         
-        XCTAssertFalse(try sut.anyView().styleConfigurationLabel(0).fixedSize().horizontal)
-        XCTAssertTrue(try sut.anyView().styleConfigurationLabel(0).fixedSize().vertical)
+        print(try sut.styleConfigurationLabel().fixedSize())
         
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).multilineTextAlignment(), .center)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).foregroundColor(), .white.opacity(1))
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().maxWidth, .infinity)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().minHeight, 44)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).font(), Font.body.weight(.semibold))
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).cornerRadius(), 16)
+        XCTAssertFalse(try sut.fixedSize().horizontal)
+        XCTAssertTrue(try sut.fixedSize().vertical)
+        
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).multilineTextAlignment(), .center)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).foregroundColor(), .white.opacity(1))
+        XCTAssertEqual(try sut.flexFrame().maxWidth, .infinity)
+        XCTAssertEqual(try sut.flexFrame().minHeight, 44)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).font(), Font.body.weight(.semibold))
+        XCTAssertEqual(try sut.cornerRadius(), 16)
     }
     
     @MainActor
@@ -42,13 +44,13 @@ extension ButtonStylesTests {
     func test_secondaryButton() throws {
         let sut = try Secondary().inspect(isPressed: false)
         
-        XCTAssertFalse(try sut.anyView().styleConfigurationLabel(0).fixedSize().horizontal)
-        XCTAssertTrue(try sut.anyView().styleConfigurationLabel(0).fixedSize().vertical)
+        XCTAssertFalse(try sut.fixedSize().horizontal)
+        XCTAssertTrue(try sut.fixedSize().vertical)
         
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).multilineTextAlignment(), .center)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).foregroundColor(), Color(.accent).opacity(1))
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().maxWidth, .infinity)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().minHeight, 44)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).multilineTextAlignment(), .center)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).foregroundColor(), Color(.accent).opacity(1))
+        XCTAssertEqual(try sut.flexFrame().maxWidth, .infinity)
+        XCTAssertEqual(try sut.flexFrame().minHeight, 44)
     }
     
     @MainActor
@@ -63,12 +65,12 @@ extension ButtonStylesTests {
     func test_supportButton() throws {
         let sut = try Support().inspect(isPressed: false)
         
-        XCTAssertFalse(try sut.anyView().styleConfigurationLabel(0).fixedSize().horizontal)
-        XCTAssertTrue(try sut.anyView().styleConfigurationLabel(0).fixedSize().vertical)
+        XCTAssertFalse(try sut.fixedSize().horizontal)
+        XCTAssertTrue(try sut.fixedSize().vertical)
         
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).multilineTextAlignment(), .leading)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).foregroundColor(), Color(.accent).opacity(1))
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().alignment, .leading)
-        XCTAssertEqual(try sut.anyView().styleConfigurationLabel(0).flexFrame().minHeight, 24)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).multilineTextAlignment(), .leading)
+        XCTAssertEqual(try sut.styleConfigurationLabel(0).foregroundColor(), Color(.accent).opacity(1))
+        XCTAssertEqual(try sut.flexFrame().alignment, .leading)
+        XCTAssertEqual(try sut.flexFrame().minHeight, 24)
     }
 }


### PR DESCRIPTION
# Update view inspector tests to work with available runner

We've known that view inspector tests have failed when run against Xcode 16.3+ for a while. A recent view inspector update has allowed fixing of the unit tests so they now run successfully on 16.3 / 16.4.

This PR updates these unit tests so that the runner configuration can be updated to use Xcode and simulator versions currently available on Github.

# Checklist

## Before raising your pull request:
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
