### PR TITLE
feat: updates QR scanner background colour

### DIFF
--- a/Sources/GDSCommon/Patterns/Scanner/ScanOverlayView.swift
+++ b/Sources/GDSCommon/Patterns/Scanner/ScanOverlayView.swift
@@ -34,7 +34,8 @@ final class ScanOverlayView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         overlayLayer.frame = frame
-        
+        overlayLayer.fillColor = UIColor.scannerBackground.cgColor
+        overlayLayer.opacity = 0.7  
         let path = UIBezierPath()
         let overlayPath = UIBezierPath(rect: bounds)
         let windowPath = UIBezierPath(roundedRect: viewfinderRect,

--- a/Sources/GDSCommon/Styles/Colours.xcassets/Colours/ScannerBackground.colorset/Contents.json
+++ b/Sources/GDSCommon/Styles/Colours.xcassets/Colours/ScannerBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/GDSCommon/Styles/UIColor+Extensions.swift
+++ b/Sources/GDSCommon/Styles/UIColor+Extensions.swift
@@ -43,7 +43,8 @@ extension UIColor {
     /// Internal method are used as `DialogBackground` and `DialogText` are not part of the GDS Design System and will be replaced and updated in the main repository in future
     internal static let dialogBackground = UIColor(.dialogBackground)
     internal static let dialogText = UIColor(.dialogText)
-   
+    internal static let scannerBackground = UIColor(.scannerBackground)
+
     /// Conforms to `CaseIterable` to allow a single test to iterate over all colours
     /// Enum for GDS Design System colours with raw type of `String` to allow type safe access to the asset catalog
     public enum GDSColours: String, CaseIterable {
@@ -73,5 +74,6 @@ extension UIColor {
         // TODO: DCMAW-6572 Review colours based on investigation from Design
         case dialogBackground = "DialogBackground"
         case dialogText = "DialogText"
+        case scannerBackground = "ScannerBackground"
     }
 }

--- a/Tests/GDSCommonTests/ScanOverlayViewTests.swift
+++ b/Tests/GDSCommonTests/ScanOverlayViewTests.swift
@@ -55,5 +55,7 @@ extension ScanOverlayViewTests {
     func testLayoutSubviews() {
         sut.layoutSubviews()
         XCTAssertEqual(sut.overlayLayer.frame, sut.frame)
+        XCTAssertEqual(sut.overlayLayer.fillColor, UIColor.scannerBackground.cgColor)
+        XCTAssertEqual(sut.overlayLayer.opacity, 0.7)
     }
 }


### PR DESCRIPTION
# DCMAW-15680: Updating background colour of GDS common QR code scanner

This PR changes the fill colour of the QR scanner to align with the latest designs. 

A new colour, `ScannerBackground` was created with #000000. The opacity is set to 70% in `ScanOverlayView`. Design's preference is to have this background colour as its own colour, rather than the system `black` in case any future opacity tweaks are needed, and to ensure the exact hex colour code is used. 

<img width="250" height="700" alt="IMG_0111" src="https://github.com/user-attachments/assets/ce32e172-4de3-46a3-9edc-87a2c7f5ac86" />

<img width="250" height="700" alt="Screenshot 2025-09-26 at 08 15 59" src="https://github.com/user-attachments/assets/5f98ee85-b15c-48c9-bb61-347c7ff97900" />


# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
